### PR TITLE
Set legend item svg to flex-basis auto.

### DIFF
--- a/src/ui/legend/src/legend-item.css
+++ b/src/ui/legend/src/legend-item.css
@@ -22,7 +22,7 @@
 
 .svg {
     margin-right: 0.25em;
-    flex: 0 0 16px;
+    flex: 0 0 auto;
 }
 
 .label {


### PR DESCRIPTION
Fixes faulty width constraint in parent element.