### PR TITLE
Option button enhancements

### DIFF
--- a/src/ui/axis-chart/demo/app.jsx
+++ b/src/ui/axis-chart/demo/app.jsx
@@ -93,7 +93,7 @@ class App extends React.Component {
         <div>
           <Button
             text="Resize and change scale"
-            clickHandler={this.onClick}
+            onClick={this.onClick}
           />
         </div>
 {/* <pre><code>

--- a/src/ui/button/demo/app.jsx
+++ b/src/ui/button/demo/app.jsx
@@ -28,7 +28,7 @@ class App extends React.Component {
           <h3>A clickable button with a new class</h3>
 {/* <pre><code>
   <Button
-    clickHandler={function onClick() { alert('You clicked me!'); }}
+    onClick={function onClick() { alert('You clicked me!'); }}
     className="new-class"
   >
     Click me!
@@ -36,7 +36,7 @@ class App extends React.Component {
 
 </code></pre> */}
           <Button
-            clickHandler={onClick}
+            onClick={onClick}
             className="new-class"
           >
             Click me!
@@ -48,14 +48,14 @@ class App extends React.Component {
   <Button
     theme="green"
     text="Click me!"
-    clickHandler={function onClick() { alert('You clicked me!'); }}
+    onClick={function onClick() { alert('You clicked me!'); }}
   />
 
 </code></pre> */}
           <Button
             theme="green"
             text="Click me!"
-            clickHandler={onClick}
+            onClick={onClick}
           />
         </section>
         <section>
@@ -64,14 +64,14 @@ class App extends React.Component {
   <Button
     disabled
     text="Click me!"
-    clickHandler={function onClick() { alert('You clicked me!'); }}
+    onClick={function onClick() { alert('You clicked me!'); }}
   />
 
 </code></pre> */}
           <Button
             text="Click me!"
             disabled
-            clickHandler={onClick}
+            onClick={onClick}
           />
         </section>
         <section>
@@ -80,7 +80,7 @@ class App extends React.Component {
   <HtmlLabel text="A button">
     <Button
       text="Click me!"
-      clickHandler={function onClick() { alert('You clicked me!'); }}
+      onClick={function onClick() { alert('You clicked me!'); }}
       theme="dark"
     />
   </HtmlLabel>
@@ -91,7 +91,7 @@ class App extends React.Component {
           >
             <Button
               text="Click me!"
-              clickHandler={onClick}
+              onClick={onClick}
             />
           </HtmlLabel>
         </section>
@@ -101,7 +101,7 @@ class App extends React.Component {
   <Button
     text="Delete all files"
     showSpinner={this.state.isLoading}
-    clickHandler={this.showIsLoading}
+    onClick={this.showIsLoading}
   />
 
 </code></pre> */}
@@ -109,7 +109,7 @@ class App extends React.Component {
             <Button
               text="Delete all files"
               showSpinner={this.state.isLoading}
-              clickHandler={this.showIsLoading}
+              onClick={this.showIsLoading}
             />
           </div>
         </section>
@@ -118,14 +118,14 @@ class App extends React.Component {
 {/* <pre><code>
   <Button
     text="Click me!"
-    clickHandler={function onClick() { alert('You clicked me!'); }}
+    onClick={function onClick() { alert('You clicked me!'); }}
     icon="home3.png"
   />
 
 </code></pre> */}
           <Button
             text="Click me!"
-            clickHandler={onClick}
+            onClick={onClick}
             icon="home3.png"
           />
         </section>
@@ -136,7 +136,7 @@ class App extends React.Component {
     text="Click me!"
     icon="home3.png"
     showSpinner={this.state.isLoading}
-    clickHandler={this.showIsLoading}
+    onClick={this.showIsLoading}
   />
 
 </code></pre> */}
@@ -144,7 +144,7 @@ class App extends React.Component {
             text="Click me!"
             icon="home3.png"
             showSpinner={this.state.isLoading}
-            clickHandler={this.showIsLoading}
+            onClick={this.showIsLoading}
           />
         </section>
       </div>

--- a/src/ui/button/demo/app.jsx
+++ b/src/ui/button/demo/app.jsx
@@ -1,9 +1,11 @@
-/* eslint no-alert:0 */
+/* eslint-disable no-alert */
 import React from 'react';
-import { render } from 'react-dom';
+import ReactDOM from 'react-dom';
 
 import Button from '../src/button';
 import HtmlLabel from '../../html-label';
+
+function onClick() { alert('You clicked me!'); }
 
 class App extends React.Component {
   constructor(props) {
@@ -15,7 +17,7 @@ class App extends React.Component {
 
   showIsLoading() {
     this.setState({
-      isLoading: !this.state.isLoading
+      isLoading: !this.state.isLoading,
     });
   }
 
@@ -23,53 +25,58 @@ class App extends React.Component {
     return (
       <div>
         <section>
-          <h3>A clickable button with some extra classes</h3>
-          <pre><code>
+          <h3>A clickable button with a new class</h3>
+{/* <pre><code>
   <Button
-    text="Click me!"
     clickHandler={function onClick() { alert('You clicked me!'); }}
-    className="an-extra-class"
-  />
-          </code></pre>
+    className="new-class"
+  >
+    Click me!
+  </Button>
+
+</code></pre> */}
           <Button
-            text="Click me!"
-            clickHandler={function onClick() { alert('You clicked me!'); }}
-            className="an-extra-class"
-          />
+            clickHandler={onClick}
+            className="new-class"
+          >
+            Click me!
+          </Button>
         </section>
         <section>
           <h3>A themed button</h3>
-          <pre><code>
+{/* <pre><code>
   <Button
     theme="green"
     text="Click me!"
     clickHandler={function onClick() { alert('You clicked me!'); }}
   />
-          </code></pre>
+
+</code></pre> */}
           <Button
             theme="green"
             text="Click me!"
-            clickHandler={function onClick() { alert('You clicked me!'); }}
+            clickHandler={onClick}
           />
         </section>
         <section>
           <h3>A disabled button</h3>
-          <pre><code>
+{/* <pre><code>
   <Button
     disabled
     text="Click me!"
     clickHandler={function onClick() { alert('You clicked me!'); }}
   />
-          </code></pre>
+
+</code></pre> */}
           <Button
             text="Click me!"
             disabled
-            clickHandler={function onClick() { alert('You clicked me!'); }}
+            clickHandler={onClick}
           />
         </section>
         <section>
           <h3>A button with a label</h3>
-          <pre><code>
+{/* <pre><code>
   <HtmlLabel text="A button">
     <Button
       text="Click me!"
@@ -77,25 +84,27 @@ class App extends React.Component {
       theme="dark"
     />
   </HtmlLabel>
-          </code></pre>
-            <HtmlLabel
-              text="A button "
-            >
-              <Button
-                text="Click me!"
-                clickHandler={function onClick() { alert('You clicked me!'); }}
-              />
-            </HtmlLabel>
+
+</code></pre> */}
+          <HtmlLabel
+            text="A button "
+          >
+            <Button
+              text="Click me!"
+              clickHandler={onClick}
+            />
+          </HtmlLabel>
         </section>
         <section>
           <h3>A button with a spinner</h3>
-          <pre><code>
+{/* <pre><code>
   <Button
     text="Delete all files"
     showSpinner={this.state.isLoading}
     clickHandler={this.showIsLoading}
   />
-          </code></pre>
+
+</code></pre> */}
           <div>
             <Button
               text="Delete all files"
@@ -106,29 +115,31 @@ class App extends React.Component {
         </section>
         <section>
           <h3>A clickable button with an image</h3>
-          <pre><code>
+{/* <pre><code>
   <Button
     text="Click me!"
     clickHandler={function onClick() { alert('You clicked me!'); }}
     icon="home3.png"
   />
-          </code></pre>
+
+</code></pre> */}
           <Button
             text="Click me!"
-            clickHandler={function onClick() { alert('You clicked me!'); }}
+            clickHandler={onClick}
             icon="home3.png"
           />
         </section>
         <section>
           <h3>A clickable button with an image which changes to a spinner when clicked</h3>
-          <pre><code>
+{/* <pre><code>
   <Button
     text="Click me!"
     icon="home3.png"
     showSpinner={this.state.isLoading}
     clickHandler={this.showIsLoading}
   />
-          </code></pre>
+
+</code></pre> */}
           <Button
             text="Click me!"
             icon="home3.png"
@@ -141,4 +152,4 @@ class App extends React.Component {
   }
 }
 
-render(<App />, document.getElementById('app'));
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/src/ui/button/demo/html-pre-tag-loader.js
+++ b/src/ui/button/demo/html-pre-tag-loader.js
@@ -1,23 +1,24 @@
-'use strict';
+const blockLoader = require('block-loader');
 
-var blockLoader = require('block-loader');
+const startPre = '<pre><code>';
+const endPre = '</code></pre>';
 
-var options = {
-  start: "<pre><code>",
-  end: "</code></pre>",
-  process: function fixPreBlocks(pre) {
-    var replaced = pre
-      .replace(options.start,'')   // first, remove the start/end delimiters, then:
-      .replace(options.end,'')     //
-      .replace(/&/g,'&amp;')       // 1. use html entity equivalent,
-      .replace(/</g,'&lt;')        // 2. use html entity equivalent,
-      .replace(/>/g,'&gt;')        // 3. use html entity equivalent,
-      .replace(/([{}])/g,"{'$1'}") // 4. JSX-safify curly braces,
-      .replace(/\n/g,"{'\\n'}");   // 5. and preserve line endings, thanks.
+const options = {
+  start: `{/* ${startPre}`,
+  end: `${endPre} */}`,
+  process: function fixBlocks(block) {
+    const replaced = block
+      .replace(options.start, '')   // first, remove the start/end delimiters, then:
+      .replace(options.end, '')     //
+      .replace(/&/g, '&amp;')       // 1. use html entity equivalent,
+      .replace(/</g, '&lt;')        // 2. use html entity equivalent,
+      .replace(/>/g, '&gt;')        // 3. use html entity equivalent,
+      .replace(/([{}])/g, "{'$1'}") // 4. JSX-safify curly braces,
+      .replace(/\n/g, "{'\\n'}");   // 5. and preserve line endings, thanks.
 
     // done! return with the delimiters put back in place
-    return options.start + replaced + options.end
-  }
+    return `${startPre}${replaced}${endPre}`;
+  },
 };
 
 module.exports = blockLoader(options);

--- a/src/ui/button/demo/webpack.config.js
+++ b/src/ui/button/demo/webpack.config.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var autoprefixer = require('autoprefixer');
+var WebpackNotifierPlugin = require('webpack-notifier');
 
 module.exports = {
   devtool: 'source-map',
@@ -11,6 +12,9 @@ module.exports = {
     path: __dirname,
     filename: 'bundle.js'
   },
+  plugins: [
+    new WebpackNotifierPlugin({alwaysNotify: true})
+  ],
   module: {
     loaders: [
       {
@@ -28,6 +32,5 @@ module.exports = {
   resolve: {
     extensions: ['', '.js', '.jsx']
   },
-  stats: false,
   progress: true
 };

--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -1,75 +1,103 @@
 import React, { PropTypes } from 'react';
-
 import classNames from 'classnames';
+import { CommonPropTypes, PureComponent, propsChanged, stateFromPropUpdates } from '../../../utils';
 
 import styles from './button.css';
 import Spinner from '../../spinner';
 
-const propTypes = {
-  /* additional class names to add to button */
-  className: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.array
-  ]),
+export default class Button extends PureComponent {
+  constructor(props) {
+    super(props);
 
-  /* additional style to add to button */
-  style: PropTypes.object,
+    this.state = stateFromPropUpdates(Button.propUpdates, {}, props, {});
+  }
 
-  clickHandler: PropTypes.func,
+  componentWillReceiveProps(nextProps) {
+    this.setState(stateFromPropUpdates(Button.propUpdates, this.props, nextProps, {}));
+  }
+
+  static calculateStyle(props) {
+    return {
+      ...props.style,
+      ...(props.disabled ? props.disabledStyle : {}),
+    };
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      clickHandler,
+      disabled,
+      disabledClassName,
+      icon,
+      id,
+      name,
+      showSpinner,
+      text,
+      theme,
+    } = this.props;
+    const {
+      style,
+    } = this.state;
+
+    return (
+      <button
+        style={style}
+        className={classNames(className, styles[theme], { [disabledClassName]: disabled })}
+        disabled={disabled}
+        id={id}
+        name={name}
+        onClick={showSpinner ? null : clickHandler}
+        type="button"
+      >
+        {showSpinner && <Spinner inline size="small" />}
+        {!showSpinner && icon && <img className={styles.icon} alt="" src={icon} />}
+        {!showSpinner && (children || text)}
+      </button>
+    );
+  }
+}
+
+Button.propTypes = {
+  /* color scheme of component; see button.css */
+  theme: PropTypes.oneOf(['green']),
+
+  className: CommonPropTypes.className,
+  style: CommonPropTypes.style,
 
   disabled: PropTypes.bool,
+  disabledClassName: CommonPropTypes.className,
+  disabledStyle: CommonPropTypes.style,
 
-  /* path to image to render within button tag */
-  icon: PropTypes.string,
+  clickHandler: PropTypes.func,
 
   id: PropTypes.string,
 
   name: PropTypes.string,
 
-  /* if true, will contain spinner */
+  /* if true, will contain spinner and not render additional content */
   showSpinner: PropTypes.bool,
+
+  /* path to image to render within button tag */
+  icon: PropTypes.string,
 
   /* text to render within button tag */
   text: PropTypes.string,
 
-  /* color scheme of component; see button.css */
-  theme: PropTypes.oneOf(['green']),
+  children: PropTypes.node,
 };
 
-const defaultProps = {
-  disabled: false
+Button.defaultProps = {
+  className: styles.common,
+  disabledClassName: styles.disabled,
 };
 
-const getContent = (showSpinner, iconPath) => {
-  if (showSpinner) return <Spinner inline size="small" />;
-  if (iconPath) return <img className={styles.icon} alt="" src={iconPath} />;
-  return null;
+Button.propUpdates = {
+  style: (state, propName, prevProps, nextProps) => {
+    if (propsChanged(prevProps, nextProps, ['style', 'disabled'])) {
+      return { ...state, style: Button.calculateStyle(nextProps) };
+    }
+    return state;
+  },
 };
-
-const Button = (props) => {
-  const clickHandler = props.showSpinner ? null : props.clickHandler;
-  return (
-    <button
-      style={props.style}
-      className={classNames(styles.common,
-                            styles[props.theme],
-                            { [styles.disabled]: props.disabled },
-                            props.className)}
-      disabled={props.disabled}
-      id={props.id}
-      name={props.name}
-      onClick={clickHandler}
-      type="button"
-    >
-      {getContent(props.showSpinner, props.icon)}
-      {!props.showSpinner ? <span>{props.text}</span> : null}
-    </button>
-  );
-};
-
-Button.propTypes = propTypes;
-
-Button.defaultProps = defaultProps;
-
-export default Button;

--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -6,6 +6,13 @@ import styles from './button.css';
 import Spinner from '../../spinner';
 
 export default class Button extends PureComponent {
+  static calculateStyle(props) {
+    return {
+      ...props.style,
+      ...(props.disabled ? props.disabledStyle : {}),
+    };
+  }
+
   constructor(props) {
     super(props);
 
@@ -16,23 +23,16 @@ export default class Button extends PureComponent {
     this.setState(stateFromPropUpdates(Button.propUpdates, this.props, nextProps, {}));
   }
 
-  static calculateStyle(props) {
-    return {
-      ...props.style,
-      ...(props.disabled ? props.disabledStyle : {}),
-    };
-  }
-
   render() {
     const {
       children,
       className,
-      clickHandler,
       disabled,
       disabledClassName,
       icon,
       id,
       name,
+      onClick,
       showSpinner,
       text,
       theme,
@@ -48,7 +48,7 @@ export default class Button extends PureComponent {
         disabled={disabled}
         id={id}
         name={name}
-        onClick={showSpinner ? null : clickHandler}
+        onClick={showSpinner ? null : onClick}
         type="button"
       >
         {showSpinner && <Spinner inline size="small" />}
@@ -60,32 +60,37 @@ export default class Button extends PureComponent {
 }
 
 Button.propTypes = {
-  /* color scheme of component; see button.css */
-  theme: PropTypes.oneOf(['green']),
+  children: PropTypes.node,
 
   className: CommonPropTypes.className,
-  style: CommonPropTypes.style,
 
   disabled: PropTypes.bool,
+
+  /* className to apply when disabled */
   disabledClassName: CommonPropTypes.className,
+
+  /* inline styles to apply when disabled */
   disabledStyle: CommonPropTypes.style,
 
-  clickHandler: PropTypes.func,
+  /* path to image to render within button tag */
+  icon: PropTypes.string,
 
   id: PropTypes.string,
 
   name: PropTypes.string,
 
+  onClick: PropTypes.func,
+
   /* if true, will contain spinner and not render additional content */
   showSpinner: PropTypes.bool,
 
-  /* path to image to render within button tag */
-  icon: PropTypes.string,
+  style: CommonPropTypes.style,
 
   /* text to render within button tag */
   text: PropTypes.string,
 
-  children: PropTypes.node,
+  /* color scheme of component; see button.css */
+  theme: PropTypes.oneOf(['green']),
 };
 
 Button.defaultProps = {

--- a/src/ui/button/test/button.test.js
+++ b/src/ui/button/test/button.test.js
@@ -6,6 +6,7 @@ import { shallow } from 'enzyme';
 
 import Button from '../src/button';
 import Spinner from '../../spinner';
+import styles from '../src/button.css';
 
 chai.use(chaiEnzyme());
 
@@ -50,5 +51,49 @@ describe('<Button />', () => {
     const wrapper = shallow(<Button icon="image.png" showSpinner />);
     expect(wrapper).to.contain(<Spinner inline size="small" />)
       .and.to.not.have.descendants('img');
+  });
+
+  describe('styles', () => {
+    it('applies disabled styles, when disabled', () => {
+      const wrapper = shallow(
+        <Button disabledStyle={{ opacity: '0.5' }} disabled />
+      );
+      expect(wrapper).to.have.style('opacity', '0.5');
+    });
+
+    it('does not apply disabled styles, when not disabled', () => {
+      const wrapper = shallow(
+        <Button disabledStyle={{ opacity: '0.5' }} />
+      );
+      expect(wrapper).to.not.have.style('opacity', '0.5');
+    });
+
+    it('applies disabled styles, when disabled prop is changed', () => {
+      const wrapper = shallow(
+        <Button disabledStyle={{ opacity: '0.5' }} />
+      );
+      expect(wrapper).to.not.have.style('opacity', '0.5');
+      wrapper.setProps({ disabled: true });
+      expect(wrapper).to.have.style('opacity', '0.5');
+      wrapper.setProps({ disabled: false });
+      expect(wrapper).to.not.have.style('opacity', '0.5');
+    });
+  });
+
+  describe('classNames', () => {
+    it('applies default disabled style, when disabled', () => {
+      const wrapper = shallow(
+        <Button disabled />
+      );
+      expect(wrapper).to.have.className(styles.disabled);
+    });
+
+    it('applies provided disabled style, when disabled', () => {
+      const wrapper = shallow(
+        <Button disabledClassName="disabled-test" disabled />
+      );
+      expect(wrapper).to.have.className('disabled-test');
+      expect(wrapper).to.not.have.className(styles.disabled);
+    });
   });
 });

--- a/src/ui/choropleth-legend/demo/app.jsx
+++ b/src/ui/choropleth-legend/demo/app.jsx
@@ -156,12 +156,12 @@ class App extends React.Component {
         />
         <Button
           text="Set color scale"
-          clickHandler={this.setScale}
+          onClick={this.setScale}
         />
         <span style={{ marginBottom: '5px' }} />
         <Button
           text="Generate new data"
-          clickHandler={this.setNewData}
+          onClick={this.setNewData}
         />
       </div>
     );

--- a/src/ui/choropleth/demo/app.jsx
+++ b/src/ui/choropleth/demo/app.jsx
@@ -120,11 +120,11 @@ class App extends React.Component {
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <Button style={{ margin: '0.2em' }}
                   text="Toggle subnational"
-                  clickHandler={this.toggleVisibility({ name: 'subnational' })}
+                  onClick={this.toggleVisibility({ name: 'subnational' })}
           />
           <Button style={{ margin: '0.2em' }}
                   text="Toggle boundaries"
-                  clickHandler={this.toggleVisibility({ type: 'mesh' })}
+                  onClick={this.toggleVisibility({ type: 'mesh' })}
           />
         </div>
       </div>

--- a/src/ui/choropleth/src/controls.jsx
+++ b/src/ui/choropleth/src/controls.jsx
@@ -9,19 +9,19 @@ const Controls = (props) => {
     <div className={classNames(style.common, props.className)} style={props.style}>
       <Button
         className={classNames(style.button, props.buttonClassName)}
-        clickHandler={props.onZoomIn}
+        onClick={props.onZoomIn}
         style={props.buttonStyle}
         text="+"
       />
       <Button
         className={classNames(style.button, props.buttonClassName)}
-        clickHandler={props.onZoomReset}
+        onClick={props.onZoomReset}
         style={props.buttonStyle}
         text="•"
       />
       <Button
         className={classNames(style.button, props.buttonClassName)}
-        clickHandler={props.onZoomOut}
+        onClick={props.onZoomOut}
         style={props.buttonStyle}
         text="-"
       />

--- a/src/ui/group/demo/app.jsx
+++ b/src/ui/group/demo/app.jsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import { render } from 'react-dom';
+import ReactDOM from 'react-dom';
+import concat from 'lodash/concat';
+import { PureComponent } from '../../../utils';
 
-import { concat } from 'lodash';
-
-import Group from '../';
-import { Option } from '../';
-
+import Group, { Option } from '../';
 
 const data = [
   { name: 'males', value: '1' },
   { name: 'females', value: '2' },
-  { name: 'both', value: '3' }
+  { name: 'both', value: '3' },
 ];
 
-class App extends React.Component {
+class App extends PureComponent {
   constructor(props) {
     super(props);
 
@@ -54,4 +52,4 @@ class App extends React.Component {
   }
 }
 
-render(<App />, document.getElementById('app'));
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/src/ui/group/demo/app.jsx
+++ b/src/ui/group/demo/app.jsx
@@ -21,7 +21,7 @@ class App extends PureComponent {
     this.isDisabled = this.isDisabled.bind(this);
   }
 
-  setSelection({ value }) {
+  setSelection(_, value) {
     this.setState({ selectedItems: value });
   }
 
@@ -32,7 +32,7 @@ class App extends PureComponent {
   render() {
     return (
       <Group
-        clickHandler={this.setSelection}
+        onClick={this.setSelection}
       >
         {
           data.map((datum, index) => {

--- a/src/ui/group/demo/html-pre-tag-loader.js
+++ b/src/ui/group/demo/html-pre-tag-loader.js
@@ -1,23 +1,24 @@
-'use strict';
+const blockLoader = require('block-loader');
 
-var blockLoader = require('block-loader');
+const startPre = '<pre><code>';
+const endPre = '</code></pre>';
 
-var options = {
-  start: "<pre><code>",
-  end: "</code></pre>",
-  process: function fixPreBlocks(pre) {
-    var replaced = pre
-      .replace(options.start,'')   // first, remove the start/end delimiters, then:
-      .replace(options.end,'')     //
-      .replace(/&/g,'&amp;')       // 1. use html entity equivalent,
-      .replace(/</g,'&lt;')        // 2. use html entity equivalent,
-      .replace(/>/g,'&gt;')        // 3. use html entity equivalent,
-      .replace(/([{}])/g,"{'$1'}") // 4. JSX-safify curly braces,
-      .replace(/\n/g,"{'\\n'}");   // 5. and preserve line endings, thanks.
+const options = {
+  start: `{/* ${startPre}`,
+  end: `${endPre} */}`,
+  process: function fixBlocks(block) {
+    const replaced = block
+      .replace(options.start, '')   // first, remove the start/end delimiters, then:
+      .replace(options.end, '')     //
+      .replace(/&/g, '&amp;')       // 1. use html entity equivalent,
+      .replace(/</g, '&lt;')        // 2. use html entity equivalent,
+      .replace(/>/g, '&gt;')        // 3. use html entity equivalent,
+      .replace(/([{}])/g, "{'$1'}") // 4. JSX-safify curly braces,
+      .replace(/\n/g, "{'\\n'}");   // 5. and preserve line endings, thanks.
 
     // done! return with the delimiters put back in place
-    return options.start + replaced + options.end
-  }
+    return `${startPre}${replaced}${endPre}`;
+  },
 };
 
 module.exports = blockLoader(options);

--- a/src/ui/group/demo/webpack.config.js
+++ b/src/ui/group/demo/webpack.config.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var autoprefixer = require('autoprefixer');
+var WebpackNotifierPlugin = require('webpack-notifier');
 
 module.exports = {
   devtool: 'source-map',
@@ -11,6 +12,9 @@ module.exports = {
     path: __dirname,
     filename: 'bundle.js'
   },
+  plugins: [
+    new WebpackNotifierPlugin({alwaysNotify: true})
+  ],
   module: {
     loaders: [
       {
@@ -28,6 +32,5 @@ module.exports = {
   resolve: {
     extensions: ['', '.js', '.jsx']
   },
-  stats: false,
   progress: true
 };

--- a/src/ui/group/src/group.css
+++ b/src/ui/group/src/group.css
@@ -24,14 +24,6 @@
   color: #27ae60;
 }
 
-.dark {
-  composes: common;
-}
-
-.light {
-  composes: common;
-}
-
 .group > *:first-child {
   border-bottom-left-radius: 4px;
   border-top-left-radius: 4px;

--- a/src/ui/group/src/group.jsx
+++ b/src/ui/group/src/group.jsx
@@ -5,13 +5,19 @@ import { CommonPropTypes, PureComponent } from '../../../utils';
 
 import styles from './group.css';
 
-const wrappedClickHandler = memoize((wrappedProps, clickHandler) => {
-  return () => {
-    clickHandler({ value: wrappedProps });
-  };
-});
-
 export default class Group extends PureComponent {
+  static clickHandlerWrapper(wrappedProps, clickHandler) {
+    return () => {
+      clickHandler({ value: wrappedProps });
+    };
+  }
+
+  constructor(props) {
+    super(props);
+
+    this.wrappedClickHandler = memoize(Group.clickHandlerWrapper);
+  }
+
   render() {
     const { children, className, clickHandler, style } = this.props;
 
@@ -21,7 +27,7 @@ export default class Group extends PureComponent {
           React.Children.map(children, (child) => {
             const childProps = {
               className: classNames(styles.common, child.props.className),
-              clickHandler: wrappedClickHandler(child.props.value, clickHandler),
+              clickHandler: this.wrappedClickHandler(child.props.value, clickHandler),
             };
 
             return React.cloneElement(child, childProps);

--- a/src/ui/group/src/group.jsx
+++ b/src/ui/group/src/group.jsx
@@ -1,76 +1,49 @@
 import React, { PropTypes } from 'react';
-
 import classNames from 'classnames';
+import memoize from 'lodash/memoize';
+import { CommonPropTypes, PureComponent } from '../../../utils';
 
 import styles from './group.css';
 
+const wrappedClickHandler = memoize((wrappedProps, clickHandler) => {
+  return () => {
+    clickHandler({ value: wrappedProps });
+  };
+});
 
-const propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ]).isRequired,
+export default class Group extends PureComponent {
+  render() {
+    const { children, className, clickHandler, style } = this.props;
 
-  className: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.array
-  ]),
+    return (
+      <div className={classNames(className)} style={style}>
+        {
+          React.Children.map(children, (child) => {
+            const childProps = {
+              className: classNames(styles.common, child.props.className),
+              clickHandler: wrappedClickHandler(child.props.value, clickHandler),
+            };
+
+            return React.cloneElement(child, childProps);
+          })
+        }
+      </div>
+    );
+  }
+}
+
+Group.propTypes = {
+  className: CommonPropTypes.className,
+  style: CommonPropTypes.style,
 
   /* function with following signature: function({ value }) */
   clickHandler: PropTypes.func,
 
-  disabledItems: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.number),
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.number,
-    PropTypes.string
-  ]),
-
   hoverHandler: PropTypes.func,
 
-  selectedItems: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.number),
-    PropTypes.arrayOf(PropTypes.string),
-    PropTypes.number,
-    PropTypes.string
-  ]),
-
-  theme: PropTypes.oneOf(['dark', 'light', 'common'])
+  children: PropTypes.node.isRequired,
 };
 
-const defaultProps = {
-  theme: 'common'
+Group.defaultProps = {
+  className: styles.group,
 };
-
-
-const Group = (props) => {
-  const { children, className, theme } = props;
-
-  const wrappedClickHandler = (wrappedProps) => {
-    return () => {
-      props.clickHandler(wrappedProps);
-    };
-  };
-
-  return (
-    <div className={classNames(className, styles.group)}>
-      {
-        React.Children.map(children, (child) => {
-          const childProps = {
-            className: classNames(styles.option, child.props.className, styles[theme], className),
-            clickHandler: wrappedClickHandler({ value: child.props.value })
-          };
-
-          return React.cloneElement(child, childProps);
-        })
-      }
-    </div>
-  );
-};
-
-Group.propTypes = propTypes;
-
-Group.defaultProps = defaultProps;
-
-export default Group;

--- a/src/ui/group/src/group.jsx
+++ b/src/ui/group/src/group.jsx
@@ -1,25 +1,23 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import memoize from 'lodash/memoize';
-import { CommonPropTypes, PureComponent } from '../../../utils';
+import { CommonPropTypes, eventHandleWrapper, PureComponent } from '../../../utils';
 
 import styles from './group.css';
 
 export default class Group extends PureComponent {
-  static clickHandlerWrapper(wrappedProps, clickHandler) {
-    return () => {
-      clickHandler({ value: wrappedProps });
-    };
+  static onClickWrapper(optionValue, onClick) {
+    return eventHandleWrapper(onClick, optionValue);
   }
 
   constructor(props) {
     super(props);
 
-    this.wrappedClickHandler = memoize(Group.clickHandlerWrapper);
+    this.wrappedOnClick = memoize(Group.onClickWrapper);
   }
 
   render() {
-    const { children, className, clickHandler, style } = this.props;
+    const { children, className, onClick, style } = this.props;
 
     return (
       <div className={classNames(className)} style={style}>
@@ -27,7 +25,7 @@ export default class Group extends PureComponent {
           React.Children.map(children, (child) => {
             const childProps = {
               className: classNames(styles.common, child.props.className),
-              clickHandler: this.wrappedClickHandler(child.props.value, clickHandler),
+              onClick: this.wrappedOnClick(child.props.value, onClick),
             };
 
             return React.cloneElement(child, childProps);
@@ -39,15 +37,12 @@ export default class Group extends PureComponent {
 }
 
 Group.propTypes = {
+  children: PropTypes.node.isRequired,
   className: CommonPropTypes.className,
   style: CommonPropTypes.style,
 
-  /* function with following signature: function({ value }) */
-  clickHandler: PropTypes.func,
-
-  hoverHandler: PropTypes.func,
-
-  children: PropTypes.node.isRequired,
+  /* function with following signature: function(event, selectedOptionValue) */
+  onClick: PropTypes.func,
 };
 
 Group.defaultProps = {

--- a/src/ui/group/src/option.jsx
+++ b/src/ui/group/src/option.jsx
@@ -1,61 +1,88 @@
 import React, { PropTypes } from 'react';
-
 import classNames from 'classnames';
+import omit from 'lodash/omit';
+import { CommonPropTypes, PureComponent, propsChanged, stateFromPropUpdates } from '../../../utils';
 
 import Button from '../../button';
-
 import styles from './group.css';
 
-const propTypes = {
-  className: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.object,
-    PropTypes.array
-  ]),
+export default class Option extends PureComponent {
+  constructor(props) {
+    super(props);
 
-  clickHandler: PropTypes.func,
+    this.state = stateFromPropUpdates(Option.propUpdates, {}, props, {});
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(stateFromPropUpdates(Option.propUpdates, this.props, nextProps, {}));
+  }
+
+  static calculateStyle(props) {
+    return {
+      ...props.style,
+      ...(props.selected ? props.selectedStyle : {}),
+      ...(props.disabled ? props.disabledStyle : {}),
+    };
+  }
+
+  render() {
+    const {
+      className,
+      disabled,
+      disabledClassName,
+      selected,
+      selectedClassName,
+      type,
+    } = this.props;
+    const {
+      style,
+    } = this.state;
+
+    return React.createElement(
+      type,
+      {
+        className: classNames(className, {
+          [selectedClassName]: selected,
+          [disabledClassName]: disabled,
+        }),
+        disabled,
+        selected,
+        style,
+        ...omit(this.props, Object.keys(Option.propTypes)),
+      }
+    );
+  }
+}
+
+Option.propTypes = {
+  className: CommonPropTypes.className,
+  style: CommonPropTypes.style,
 
   /* apply disabled class styling */
   disabled: PropTypes.bool,
-
-  hoverHandler: PropTypes.func,
-
-  /* path to image to render within label tag */
-  icon: PropTypes.string,
+  disabledClassName: CommonPropTypes.className,
+  disabledStyle: CommonPropTypes.style,
 
   /* apply selected class styling */
   selected: PropTypes.bool,
-
-  /* text to render within label tag */
-  text: PropTypes.string,
+  selectedClassName: CommonPropTypes.className,
+  selectedStyle: CommonPropTypes.style,
 
   /* react element to be wrapped by this option */
-  type: PropTypes.any
+  type: PropTypes.any,
 };
 
-const defaultProps = {
-  type: Button
+Option.defaultProps = {
+  type: Button,
+  selectedClassName: styles.selected,
+  disabledClassName: styles.disabled,
 };
 
-const Option = (props) => {
-  return React.createElement(
-    props.type,
-    {
-      className: classNames(props.className, {
-        [styles.disabled]: props.disabled,
-        [styles.selected]: props.selected
-      }),
-      clickHandler: props.clickHandler,
-      disabled: props.disabled,
-      hoverHandler: props.hoverHandler,
-      icon: props.icon,
-      text: props.text
+Option.propUpdates = {
+  style: (state, propName, prevProps, nextProps) => {
+    if (propsChanged(prevProps, nextProps, ['style', 'selected', 'disabled'])) {
+      return { ...state, style: Option.calculateStyle(nextProps) };
     }
-  );
+    return state;
+  },
 };
-
-Option.propTypes = propTypes;
-
-Option.defaultProps = defaultProps;
-
-export default Option;

--- a/src/ui/group/src/option.jsx
+++ b/src/ui/group/src/option.jsx
@@ -7,6 +7,14 @@ import Button from '../../button';
 import styles from './group.css';
 
 export default class Option extends PureComponent {
+  static calculateStyle(props) {
+    return {
+      ...props.style,
+      ...(props.selected ? props.selectedStyle : {}),
+      ...(props.disabled ? props.disabledStyle : {}),
+    };
+  }
+
   constructor(props) {
     super(props);
 
@@ -15,14 +23,6 @@ export default class Option extends PureComponent {
 
   componentWillReceiveProps(nextProps) {
     this.setState(stateFromPropUpdates(Option.propUpdates, this.props, nextProps, {}));
-  }
-
-  static calculateStyle(props) {
-    return {
-      ...props.style,
-      ...(props.selected ? props.selectedStyle : {}),
-      ...(props.disabled ? props.disabledStyle : {}),
-    };
   }
 
   render() {
@@ -56,7 +56,6 @@ export default class Option extends PureComponent {
 
 Option.propTypes = {
   className: CommonPropTypes.className,
-  style: CommonPropTypes.style,
 
   /* apply disabled class styling */
   disabled: PropTypes.bool,
@@ -68,14 +67,16 @@ Option.propTypes = {
   selectedClassName: CommonPropTypes.className,
   selectedStyle: CommonPropTypes.style,
 
+  style: CommonPropTypes.style,
+
   /* react element to be wrapped by this option */
   type: PropTypes.any,
 };
 
 Option.defaultProps = {
-  type: Button,
-  selectedClassName: styles.selected,
   disabledClassName: styles.disabled,
+  selectedClassName: styles.selected,
+  type: Button,
 };
 
 Option.propUpdates = {

--- a/src/ui/group/test/.eslintrc.js
+++ b/src/ui/group/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  "rules": {
+    "no-unused-expressions": 0
+  }
+};

--- a/src/ui/group/test/group.test.js
+++ b/src/ui/group/test/group.test.js
@@ -22,12 +22,13 @@ describe('<Group />', () => {
   });
 
   it('handles clicks', () => {
-    const clickHandler = sinon.spy(({ value }) => {
+    const mockEvent = {};
+    const clickHandler = sinon.spy((evt, value) => {
       return value;
     });
 
     const wrapper = mount(
-      <Group clickHandler={clickHandler}>
+      <Group onClick={clickHandler}>
         <Option value={1} text="One" id="clickMe" selected />
         <Option value={2} text="Two" />
         <Option value={3} text="Three" disabled />
@@ -37,6 +38,6 @@ describe('<Group />', () => {
     const button = wrapper.find('#clickMe');
     button.simulate('click');
     expect(clickHandler.called).to.be.true;
-    expect(clickHandler.calledWithMatch({ value: 1 })).to.be.true;
+    expect(clickHandler.calledWithMatch(mockEvent, 1)).to.be.true;
   });
 });

--- a/src/ui/group/test/group.test.js
+++ b/src/ui/group/test/group.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
-
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
 
 import Group, { Option } from '../';
 
@@ -12,12 +12,31 @@ describe('<Group />', () => {
   it('renders options as buttons', () => {
     const wrapper = shallow(
       <Group>
-        <Option key={1} text="One" selected />
-        <Option key={2} text="Two" />
-        <Option key={3} text="Three" disabled />
+        <Option value={1} text="One" selected />
+        <Option value={2} text="Two" />
+        <Option value={3} text="Three" disabled />
       </Group>
     );
 
     expect(wrapper).to.have.exactly(3).descendants('Option');
+  });
+
+  it('handles clicks', () => {
+    const clickHandler = sinon.spy(({ value }) => {
+      return value;
+    });
+
+    const wrapper = mount(
+      <Group clickHandler={clickHandler}>
+        <Option value={1} text="One" id="clickMe" selected />
+        <Option value={2} text="Two" />
+        <Option value={3} text="Three" disabled />
+      </Group>
+    );
+
+    const button = wrapper.find('#clickMe');
+    button.simulate('click');
+    expect(clickHandler.called).to.be.true;
+    expect(clickHandler.calledWithMatch({ value: 1 })).to.be.true;
   });
 });

--- a/src/ui/group/test/option.test.js
+++ b/src/ui/group/test/option.test.js
@@ -15,6 +15,12 @@ describe('<Option />', () => {
     expect(wrapper).to.have.exactly(1).descendants('Button');
   });
 
+  it('renders another type of element', () => {
+    const Component = () => { return <a />; };
+    const wrapper = shallow(<Option type={Component} />);
+    expect(wrapper).to.have.exactly(1).descendants('Component');
+  });
+
   describe('styles', () => {
     it('applies disabled styles, when disabled', () => {
       const wrapper = shallow(

--- a/src/ui/group/test/option.test.js
+++ b/src/ui/group/test/option.test.js
@@ -64,4 +64,20 @@ describe('<Option />', () => {
       expect(wrapper).to.not.have.className(styles.disabled);
     });
   });
+
+  describe('props', () => {
+    it('passes non-Option props down to whatever element it renders', () => {
+      const wrapper = shallow(
+        <Option foo="bar" />
+      );
+      expect(wrapper.find('Button')).to.have.prop('foo', 'bar');
+    });
+
+    it('does not pass Option props down to whatever element it renders', () => {
+      const wrapper = shallow(
+        <Option selectedStyle={{ display: 'none' }} />
+      );
+      expect(wrapper.find('Button')).to.have.not.have.prop('selectedStyle');
+    });
+  });
 });

--- a/src/ui/group/test/option.test.js
+++ b/src/ui/group/test/option.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { shallow } from 'enzyme';
 
 import { Option } from '../';
+import styles from '../src/group.css';
 
 chai.use(chaiEnzyme());
 
@@ -13,5 +13,49 @@ describe('<Option />', () => {
     const wrapper = shallow(<Option key={1} text="One" value="1" />);
 
     expect(wrapper).to.have.exactly(1).descendants('Button');
+  });
+
+  describe('styles', () => {
+    it('applies disabled styles, when disabled', () => {
+      const wrapper = shallow(
+        <Option disabledStyle={{ opacity: '0.5' }} disabled />
+      );
+      expect(wrapper).to.have.style('opacity', '0.5');
+    });
+
+    it('does not apply disabled styles, when not disabled', () => {
+      const wrapper = shallow(
+        <Option disabledStyle={{ opacity: '0.5' }} />
+      );
+      expect(wrapper).to.not.have.style('opacity', '0.5');
+    });
+
+    it('applies disabled styles, when disabled prop is changed', () => {
+      const wrapper = shallow(
+        <Option disabledStyle={{ opacity: '0.5' }} />
+      );
+      expect(wrapper).to.not.have.style('opacity', '0.5');
+      wrapper.setProps({ disabled: true });
+      expect(wrapper).to.have.style('opacity', '0.5');
+      wrapper.setProps({ disabled: false });
+      expect(wrapper).to.not.have.style('opacity', '0.5');
+    });
+  });
+
+  describe('classNames', () => {
+    it('applies default disabled style, when disabled', () => {
+      const wrapper = shallow(
+        <Option disabled />
+      );
+      expect(wrapper).to.have.className(styles.disabled);
+    });
+
+    it('applies provided disabled style, when disabled', () => {
+      const wrapper = shallow(
+        <Option disabledClassName="disabled-test" disabled />
+      );
+      expect(wrapper).to.have.className('disabled-test');
+      expect(wrapper).to.not.have.className(styles.disabled);
+    });
   });
 });

--- a/src/ui/legend/demo/app.jsx
+++ b/src/ui/legend/demo/app.jsx
@@ -133,7 +133,7 @@ const items = [
           />
           <Button
             text="Reset"
-            clickHandler={this.reset}
+            onClick={this.reset}
           />
         </section>
       </div>

--- a/src/ui/slider/demo/app.jsx
+++ b/src/ui/slider/demo/app.jsx
@@ -131,7 +131,7 @@ class App extends React.Component {
           <div>
             <Button
               text="Set new min/max"
-              clickHandler={this.setNewMinMax}
+              onClick={this.setNewMinMax}
             />
           </div>
           <div>
@@ -144,7 +144,7 @@ class App extends React.Component {
           <div>
             <Button
               text="Set new width"
-              clickHandler={this.setNewWidth}
+              onClick={this.setNewWidth}
             />
           </div>
           <div>
@@ -153,7 +153,7 @@ class App extends React.Component {
           <div>
             <Button
               text="Set new font size"
-              clickHandler={this.setNewFontSize}
+              onClick={this.setNewFontSize}
             />
           </div>
           <div>


### PR DESCRIPTION
This resolves an issue with `Group` and `Option`s not showing correct styling because `Button` was stomping on them.

Cleaned up `className` handling.
Added new `className` and `style` props for `selected` and `disabled`.
Made `Group`, `Option`, and `Button` extend `PureComponent` for efficient rendering.
Tried to maintain backwards compatibility as much as possible.

@davschne: Please review this and make sure it suits your needs