### PR TITLE
Enhancement/slider backing list

### DIFF
--- a/src/ui/slider/demo/app.jsx
+++ b/src/ui/slider/demo/app.jsx
@@ -26,8 +26,8 @@ class App extends React.Component {
         precision: 5,
       },
       rangeValue: {
-        low: 2001,
-        high: 2025,
+        low: undefined,
+        high: undefined,
       },
       singleValue: 2015,
       singleFillStyle: {

--- a/src/ui/slider/demo/app.jsx
+++ b/src/ui/slider/demo/app.jsx
@@ -89,15 +89,9 @@ class App extends React.Component {
     const precision = +getValueOrPlaceholder(document.getElementById('newPrecision'));
 
     const newExtent = [minExtent, maxExtent].sort((a, b) => { return a - b; });
-    // const oldExtent = [this.state.minValue, this.state.maxValue];
 
     const newSteps = +document.getElementById('newSteps').value ||
                        (newExtent[1] - newExtent[0] + 1);
-
-    // const valueSetter = (value, step) => {
-    //   return valueWithPrecision(numFromPercent(percentOfRange(value, oldExtent), newExtent),
-    //                             getFloatPrecision(step));
-    // };
 
     this.setState({
       range: {
@@ -186,12 +180,11 @@ class App extends React.Component {
 {/* <pre><code>
     <Slider
       width={200}
-      minValue={2001}
-      maxValue={2025}
+      range={{ low: 2001, high: 2005 }}
       onChange={function (value, key) {...}}
       value={{
-        min: 2001, //(initially)
-        max: 2005, //(initially)
+        low: 2001,  // (initially)
+        high: 2025, // (initially)
       }}
       fill
       ticks
@@ -212,8 +205,7 @@ class App extends React.Component {
 {/* <pre><code>
     <Slider
       width={200}
-      minValue={2001}
-      maxValue={2025}
+      range={{ low: 2001, high: 2005 }}
       onChange={function (value, key) {...}}
       value={2015} // (initially)
       fill
@@ -243,8 +235,7 @@ class App extends React.Component {
     items = ['red', 'orange', 'yellow', ...];
     <Slider
       width={200}
-      minValue={0}
-      maxValue={items.length - 1}
+      range={items}
       onChange={function (value, key) {...}}
       value={this.state.value}
       labelFunc={function (value) {...}}

--- a/src/ui/slider/demo/app.jsx
+++ b/src/ui/slider/demo/app.jsx
@@ -63,17 +63,17 @@ class App extends React.Component {
   }
 
 
-  onChange(value, key) {
-    console.log(key, value);
+  onChange(event, value) {
+    console.log(value);
     this.setState({ rangeValue: value });
   }
 
-  onSingleValueChange(value) {
+  onSingleValueChange(event, value) {
     console.log(value);
     this.setState({ singleValue: value });
   }
 
-  onListValueChange(value) {
+  onListValueChange(event, value) {
     console.log(value);
     this.setState({
       listValue: value,

--- a/src/ui/slider/src/fill.jsx
+++ b/src/ui/slider/src/fill.jsx
@@ -26,24 +26,24 @@ export default class Fill extends PureComponent {
 }
 
 Fill.propTypes = {
+  className: CommonPropTypes.className,
   direction: PropTypes.oneOf(['left', 'right']),
   height: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
   ]),
+  style: PropTypes.object,
   width: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
   ]),
-  style: PropTypes.object,
-  className: CommonPropTypes.className,
 };
 
 Fill.defaultProps = {
   direction: 'left',
   height: '100%',
-  width: 200,
   style: {
     backgroundColor: '#ccc',
   },
+  width: 200,
 };

--- a/src/ui/slider/src/handle.jsx
+++ b/src/ui/slider/src/handle.jsx
@@ -82,27 +82,21 @@ export default class Handle extends PureComponent {
 
 Handle.propTypes = {
   className: CommonPropTypes.className,
-  style: PropTypes.object,
-  snapTarget: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.object,
-  ]).isRequired,
   direction: PropTypes.oneOf(['left', 'right', 'middle']),
-  position: PropTypes.number.isRequired,
-
-  /* label and labelFunc control what is displayed on the handle */
   label: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
   ]).isRequired,
   labelFunc: PropTypes.func,
-
-  /* value key name */
   name: PropTypes.string.isRequired,
-
-  /* events */
-  onMove: PropTypes.func.isRequired,
   onKeyDown: PropTypes.func,
+  onMove: PropTypes.func.isRequired,
+  position: PropTypes.number.isRequired,
+  snapTarget: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+  ]).isRequired,
+  style: PropTypes.object,
 };
 
 Handle.defaultProps = {

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -340,8 +340,8 @@ Slider.propTypes = {
   range: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.shape({
-      low: PropTypes.number,
-      high: PropTypes.number,
+      low: PropTypes.number.isRequired,
+      high: PropTypes.number.isRequired,
       steps: PropTypes.number,
       precision: PropTypes.number,
     }),
@@ -369,8 +369,8 @@ Slider.propTypes = {
     PropTypes.string,
     PropTypes.array,
     PropTypes.shape({
-      low: PropTypes.number,
-      high: PropTypes.number,
+      low: PropTypes.any,
+      high: PropTypes.any,
     }),
   ]).isRequired,
 
@@ -409,6 +409,7 @@ Slider.propUpdates = {
     return { indexes: getIndexesForValues(getLowHighValues(nextProp), state.range) };
   }),
   width: updateFunc(() => {
+    // Track needs to be rendered with new width before Handles and Fill can be rendered
     return { render: false };
   }),
 };

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -180,9 +180,12 @@ export default class Slider extends PureComponent {
 
   updateValueFromEvent(event, index, key) {
     if (index !== this.state.indexes[key] && this.state.range[index]) {
-      const values = getValuesForIndexes({ ...this.state.indexes, [key]: index }, this.state.range);
+      const indexes = { ...this.state.indexes, [key]: index };
+      const values = getValuesForIndexes(indexes, this.state.range);
 
-      if (values.high === undefined || values.low <= values.high) {
+      if (indexes.low === undefined ||
+            indexes.high === undefined ||
+            indexes.low <= indexes.high) {
         this.props.onChange(event, values, this);
       }
     }

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -26,10 +26,15 @@ import style from './style.css';
  */
 function getIndexesForValues(values, rangeList) {
   return reduce(values, (acc, value, key) => {
+    /* eslint-disable no-nested-ternary */
+    // if value is not in the range list, assign either first or last element, depending on key
+    const index = rangeList.indexOf(value);
     return {
       ...acc,
-      [key]: rangeList.indexOf(value),
+      [key]: index !== -1 ?
+               index : key === 'low' ? 0 : rangeList.length - 1,
     };
+    /* eslint-enable no-nested-ternary */
   }, {});
 }
 

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import d3Scale from 'd3-scale';
 import bindAll from 'lodash/bindAll';
+import difference from 'lodash/difference';
 import identity from 'lodash/identity';
 import inRange from 'lodash/inRange';
 import map from 'lodash/map';
@@ -17,6 +18,8 @@ import Fill from './fill';
 import Handle from './handle';
 import ResponsiveContainer from '../../responsive-container';
 import style from './style.css';
+
+const VALUE_KEYS = ['low', 'high'];
 
 /**
  * Return object of indexes for 'low' and 'high' values
@@ -60,8 +63,11 @@ function getValuesForIndexes(indexes, rangeList) {
  */
 function getLowHighValues(value) {
   if (Array.isArray(value)) {
-    return zipObject(['low', 'high'], value);
+    return zipObject(VALUE_KEYS, value);
   } else if (typeof value === 'object') {
+    if (difference(Object.keys(value), VALUE_KEYS).length) {
+      throw new TypeError(`Unexpected value keys: [${difference(Object.keys(value), VALUE_KEYS)}]`);
+    }
     return value;
   }
   return { low: value };

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -67,19 +67,6 @@ function getLowHighValues(value) {
   return { low: value };
 }
 
-/**
- * Return value more similar to the input value. If one handle, only return number value.
- * @param value
- * @param handleCount
- * @returns {*}
- */
-function valueByHandleCount(value, handleCount) {
-  if (handleCount === 1) {
-    return value.low;
-  }
-  return value;
-}
-
 export default class Slider extends PureComponent {
   constructor(props) {
     super(props);
@@ -190,7 +177,7 @@ export default class Slider extends PureComponent {
       const values = getValuesForIndexes({ ...this.state.indexes, [key]: index }, this.state.range);
 
       if (values.high === undefined || values.low <= values.high) {
-        this.props.onChange(event, valueByHandleCount({ ...values }, this.handleCount), this);
+        this.props.onChange(event, values, this);
       }
     }
   }

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -144,7 +144,7 @@ export default class Slider extends PureComponent {
       if (!inRange(pageX - handleExtent, nextPos - handleExtent) ||
             !this.state.range[index]) return;
 
-      this.updateValueFromEvent(index, key);
+      this.updateValueFromEvent(event, index, key);
     };
   }
 
@@ -167,7 +167,7 @@ export default class Slider extends PureComponent {
 
       const index = this.state.indexes[key] + step;
 
-      this.updateValueFromEvent(index, key);
+      this.updateValueFromEvent(event, index, key);
     };
   }
 
@@ -182,15 +182,15 @@ export default class Slider extends PureComponent {
 
     const key = comp ? 'low' : 'high';
 
-    this.updateValueFromEvent(index, key);
+    this.updateValueFromEvent(event, index, key);
   }
 
-  updateValueFromEvent(index, key) {
+  updateValueFromEvent(event, index, key) {
     if (index !== this.state.indexes[key] && this.state.range[index]) {
       const values = getValuesForIndexes({ ...this.state.indexes, [key]: index }, this.state.range);
 
       if (values.high === undefined || values.low <= values.high) {
-        this.props.onChange(valueByHandleCount({ ...values }, this.handleCount), key);
+        this.props.onChange(event, valueByHandleCount({ ...values }, this.handleCount), this);
       }
     }
   }
@@ -330,9 +330,9 @@ Slider.propTypes = {
 
   /*
    * callback function when value is changed.
-   * Params:
-   *   value - object with keys ['low'] and 'high'
-   *   key - key of most recent value change.
+   * @param {Object} event - triggered the action
+   * @param {Object} value - low and high values
+   * @param {Object} Slider - the slider object itself
    */
   onChange: PropTypes.func.isRequired,
 

--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -305,14 +305,36 @@ export default class Slider extends PureComponent {
 }
 
 Slider.propTypes = {
-  /* class name styles applied to outermost wrapper */
-  wrapperClassName: CommonPropTypes.className,
-  wrapperStyle: PropTypes.object,
+  /* include fill in the track to indicate value. */
+  fill: PropTypes.bool,
+  fillClassName: CommonPropTypes.className,
+  fillStyle: PropTypes.object,
 
   fontSize: PropTypes.string,
 
-  /* width and height of Slider component. */
-  width: PropTypes.number,
+  handleClassName: CommonPropTypes.className,
+  handleStyle: PropTypes.object,
+
+  /*
+   * function applied to the selected value prior to rendering.
+   * Params:
+   *   value - selected value
+   *
+   * Returns:
+   *   'string'
+   *
+   * Default:
+   *   _.identity
+   */
+  labelFunc: PropTypes.func,
+
+  /*
+   * callback function when value is changed.
+   * Params:
+   *   value - object with keys ['low'] and 'high'
+   *   key - key of most recent value change.
+   */
+  onChange: PropTypes.func.isRequired,
 
   /* extents of slider values. */
   range: PropTypes.oneOfType([
@@ -324,6 +346,18 @@ Slider.propTypes = {
       precision: PropTypes.number,
     }),
   ]).isRequired,
+
+  /* class name and style for each tick */
+  tickClassName: CommonPropTypes.className,
+  tickStyle: PropTypes.object,
+
+  /* show ticks in track */
+  ticks: PropTypes.bool,
+  ticksClassName: CommonPropTypes.className,
+  ticksStyle: PropTypes.object,
+
+  trackClassName: CommonPropTypes.className,
+  trackStyle: PropTypes.object,
 
   /*
    * Initial selected value.
@@ -340,52 +374,20 @@ Slider.propTypes = {
     }),
   ]).isRequired,
 
-  /*
-   * function applied to the selected value prior to rendering.
-   * Params:
-   *   value - selected value
-   *
-   * Returns:
-   *   'string'
-   *
-   * Default:
-   *   _.identity
-   */
-  labelFunc: PropTypes.func,
+  /* width and height of Slider component. */
+  width: PropTypes.number,
 
-  handleClassName: CommonPropTypes.className,
-  handleStyle: PropTypes.object,
-
-  trackClassName: CommonPropTypes.className,
-  trackStyle: PropTypes.object,
-
-  /* include fill in the track to indicate value. */
-  fill: PropTypes.bool,
-  fillClassName: CommonPropTypes.className,
-  fillStyle: PropTypes.object,
-
-  /* show ticks in track */
-  ticks: PropTypes.bool,
-  ticksClassName: CommonPropTypes.className,
-  ticksStyle: PropTypes.object,
-  /* class name and style for each tick */
-  tickClassName: CommonPropTypes.className,
-  tickStyle: PropTypes.object,
-
-  /*
-   * callback function when value is changed.
-   * Params:
-   *   value - object with keys ['low'] and 'high'
-   *   key - key of most recent value change.
-   */
-  onChange: PropTypes.func.isRequired,
+  /* class name styles applied to outermost wrapper */
+  wrapperClassName: CommonPropTypes.className,
+  wrapperStyle: PropTypes.object,
 };
 
 Slider.defaultProps = {
-  width: 200,
   labelFunc: identity,
+  width: 200,
 };
 
+/* Order is important here. */
 Slider.propUpdates = {
   range: updateFunc((nextProp, propName, nextProps, state) => {
     let nextRange = nextProp;

--- a/src/ui/slider/src/track.jsx
+++ b/src/ui/slider/src/track.jsx
@@ -89,19 +89,24 @@ export default class Track extends PureComponent {
 }
 
 Track.propTypes = {
-  className: CommonPropTypes.className,
-  style: PropTypes.object,
   children: PropTypes.node,
+
+  className: CommonPropTypes.className,
+
   onClick: PropTypes.func.isRequired,
+
   snapTarget: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.object,
   ]).isRequired,
 
+  style: PropTypes.object,
+
+  tickClassName: CommonPropTypes.className,
+  tickStyle: PropTypes.object,
+
   /* show ticks */
   ticks: PropTypes.bool,
   ticksClassName: CommonPropTypes.className,
   ticksStyle: PropTypes.object,
-  tickClassName: CommonPropTypes.className,
-  tickStyle: PropTypes.object,
 };

--- a/src/ui/slider/src/util.js
+++ b/src/ui/slider/src/util.js
@@ -1,24 +1,5 @@
 import interact from 'interact.js';
 
-/**
- * Determine the floating point precision of a number.
- * @param value
- * @returns {number}
- */
-export function getFloatPrecision(value) {
-  return value > 0 && value < 1 ? (1 - Math.ceil(Math.log(value) / Math.log(10))) : 0;
-}
-
-/**
- * Return a number to a specified precision as a workaround for floating point funkiness.
- * @param value
- * @param precision
- * @returns {number}
- */
-export function valueWithPrecision(value, precision) {
-  return +value.toFixed(precision);
-}
-
 export function getSnapTargetFunc(snapTarget, snapGridArgs = {}) {
   if (typeof snapTarget === 'function') {
     return snapTarget;

--- a/src/ui/slider/test/handle.test.js
+++ b/src/ui/slider/test/handle.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import chai, { expect } from 'chai';
+import chaiEnzyme from 'chai-enzyme';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import Handle from '../src/handle';
+
+chai.use(chaiEnzyme());
+
+describe('<Handle />', () => {
+  const onMove = sinon.spy();
+
+  it('creates a handle with expected style', () => {
+    const wrapper = mount(
+      <Handle
+        label={1}
+        name={'low'}
+        onMove={onMove}
+        position={0}
+        snapTarget={{ x: 1 }}
+      />
+    );
+    expect(wrapper.instance().state.style).to.deep.equal({ left: '0px' });
+    wrapper.setProps({ position: 1 });
+    expect(wrapper.instance().state.style).to.deep.equal({ left: '1px' });
+  });
+});

--- a/src/ui/slider/test/slider.test.js
+++ b/src/ui/slider/test/slider.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import chai, { expect } from 'chai';
+import chaiEnzyme from 'chai-enzyme';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import Slider from '../src/slider';
+
+chai.use(chaiEnzyme());
+
+describe('<Slider />', () => {
+  const onChange = sinon.spy();
+
+  it('creates expected backing list', () => {
+    const wrapper = mount(
+      <Slider
+        range={{
+          low: 1,
+          high: 10,
+        }}
+        value={{
+          low: 1,
+          high: 10,
+        }}
+        onChange={onChange}
+        fill
+      />
+    );
+    expect(wrapper.instance().state.range).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(wrapper.instance().state.indexes).to.deep.equal({ low: 0, high: 9 });
+    wrapper.setProps({ value: { low: 2, high: 10 } });
+    expect(wrapper.instance().state.indexes).to.deep.equal({ low: 1, high: 9 });
+  });
+});

--- a/src/ui/slider/test/util.test.js
+++ b/src/ui/slider/test/util.test.js
@@ -2,32 +2,10 @@ import { expect } from 'chai';
 
 import {
   getDimension,
-  getFloatPrecision,
   getSnapTargetFunc,
-  valueWithPrecision,
 } from '../src/util';
 
 describe('slider.utils', () => {
-  describe('getFloatPrecision', () => {
-    it('finds the number of decimal places in a float', () => {
-      expect(getFloatPrecision(1)).to.equal(0);
-      expect(getFloatPrecision(1.0)).to.equal(0); // this is ok
-      expect(getFloatPrecision(0.1)).to.equal(1);
-      expect(getFloatPrecision(0.01)).to.equal(2);
-      expect(getFloatPrecision(0.001)).to.equal(3);
-    });
-  });
-
-  describe('valueWithPrecision', () => {
-    it('returns a number rounded to specified precision', () => {
-      expect(valueWithPrecision(0.123456789, 0)).to.equal(0);
-      expect(valueWithPrecision(0.123456789, 1)).to.equal(0.1);
-      expect(valueWithPrecision(0.123456789, 2)).to.equal(0.12);
-      expect(valueWithPrecision(0.123456789, 3)).to.equal(0.123);
-      expect(valueWithPrecision(0.123456789, 4)).to.equal(0.1235);
-    });
-  });
-
   describe('getSnapTargetFunc', () => {
     it('returns argument if snapTarget argument type is function', () => {
       const snapTarget = { x: 0, y: 0 };

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -105,7 +105,7 @@ export function stateFromPropUpdates(propUpdates, prevProps, nextProps, state) {
 export function updateFunc(func) {
   return (acc, key, prevProps = {}, nextProps) => {
     return prevProps[key] !== nextProps[key] ?
-      { ...acc, ...func(nextProps[key], key, nextProps) } :
+      { ...acc, ...func(nextProps[key], key, nextProps, acc) } :
       acc;
   };
 }
@@ -123,5 +123,6 @@ export function updateFunc(func) {
  * @param {any} nextProp
  * @param {string} propName
  * @param {Object} nextProps
+ * @param {Object} state accumulator
  * @returns {Object} accumulated state.
  */


### PR DESCRIPTION
To mitigate floating point math type errors, `<Slider />` will always either generate a backing array created from `range` prop object, or accept an array as the `range` prop. This change replaces  `minValue` and `maxValue` with the `range` object.
`min` and `max` have been replaced with `low` and `high`.

`range` will take the following form:
```javascript
range: {
    low: // range extent low
    high: // range extent high
    steps: // number of steps between extents (optional, if low/high are `int`)
    precision: // precision to round values (optional, if low/high are `int` and steps is omitted)
}
```
or
```javascript
range: [1990, 1991, 1992, ...]
```
