### PR TITLE
Enhancement/choropleth updates for disputed territories

### DIFF
--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -243,7 +243,7 @@ export default class Choropleth extends React.Component {
               key={key}
               features={this.state.cache.feature[layer.name].features}
               data={this.state.processedData}
-              keyField={this.props.geoJSONKeyField}
+              keyField={this.props.geometryKeyField}
               valueField={this.props.valueField}
               pathGenerator={this.state.pathGenerator}
               colorScale={this.props.colorScale}
@@ -356,14 +356,28 @@ Choropleth.propTypes = {
   /* array of datum objects */
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 
-  /* unique key of datum */
+  /*
+    unique key of datum
+    if a function, will be called with the datum object as first parameter
+  */
   keyField: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
   ]).isRequired,
 
-  /* mapping of datum key field to geoJSON feature key. default: 'id' (from <Feature />) */
-  geoJSONKeyField: PropTypes.string,
+  /*
+    uniquely identifying field of geometry objects
+    if a function, will be called with the geometry object as first parameter
+    N.B.: the resolved value of this prop should match the resolved value of `keyField` above
+    e.g., if data objects are of the following shape: { location_id: <number>, mean: <number> }
+          and if features within topojson are of the following shape: { type: <string>, properties: { location_id: <number> }, arcs: <array> }
+          `keyField` may be one of the following: 'location_id', or (datum) => datum.location_id
+          `geometryKeyField` may be one of the following: 'location_id' or (feature) => feature.properties.location_id
+  */
+  geometryKeyField: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]).isRequired,
 
   /* key of datum that holds the value to display */
   valueField: PropTypes.oneOfType([

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -397,19 +397,19 @@ Choropleth.propTypes = {
   /* height of containing element, in px */
   height: PropTypes.number,
 
-  /* passed to each path; signature: function(event, locationId) {...} */
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
   onClick: PropTypes.func,
 
-  /* passed to each path; signature: function(event, locationId) {...} */
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
   onMouseOver: PropTypes.func,
 
-  /* passed to each path; signature: function(event, locationId) {...} */
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
   onMouseMove: PropTypes.func,
 
-  /* passed to each path; signature: function(event, locationId) {...} */
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
   onMouseDown: PropTypes.func,
 
-  /* passed to each path; signature: function(event, locationId) {...} */
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
   onMouseOut: PropTypes.func,
 
   /* show zoom controls */

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -253,10 +253,10 @@ export default class Choropleth extends React.Component {
               colorScale={this.props.colorScale}
               selectedLocations={this.props.selectedLocations}
               onClick={this.props.onClick}
-              onMouseOver={this.props.onMouseOver}
-              onMouseMove={this.props.onMouseMove}
               onMouseDown={this.props.onMouseDown}
-              onMouseOut={this.props.onMouseOut}
+              onMouseLeave={this.props.onMouseLeave}
+              onMouseMove={this.props.onMouseMove}
+              onMouseOver={this.props.onMouseOver}
               pathClassName={layer.className}
               pathSelectedClassName={layer.selectedClassName}
               pathStyle={layer.style}
@@ -405,16 +405,16 @@ Choropleth.propTypes = {
   onClick: PropTypes.func,
 
   /* passed to each path; signature: function(event, locationId, Path) {...} */
-  onMouseOver: PropTypes.func,
+  onMouseDown: PropTypes.func,
+
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
+  onMouseLeave: PropTypes.func,
 
   /* passed to each path; signature: function(event, locationId, Path) {...} */
   onMouseMove: PropTypes.func,
 
   /* passed to each path; signature: function(event, locationId, Path) {...} */
-  onMouseDown: PropTypes.func,
-
-  /* passed to each path; signature: function(event, locationId, Path) {...} */
-  onMouseOut: PropTypes.func,
+  onMouseOver: PropTypes.func,
 
   /* show zoom controls */
   controls: PropTypes.bool,

--- a/src/ui/choropleth/src/feature-layer.jsx
+++ b/src/ui/choropleth/src/feature-layer.jsx
@@ -48,10 +48,10 @@ export default class FeatureLayer extends PureComponent {
       data,
       keyField,
       onClick,
-      onMouseOver,
-      onMouseMove,
       onMouseDown,
-      onMouseOut,
+      onMouseLeave,
+      onMouseMove,
+      onMouseOver,
       pathGenerator,
       pathClassName,
       pathSelectedClassName,
@@ -88,10 +88,10 @@ export default class FeatureLayer extends PureComponent {
                 fill={fill}
                 locationId={key}
                 onClick={onClick}
-                onMouseOver={onMouseOver}
-                onMouseMove={onMouseMove}
                 onMouseDown={onMouseDown}
-                onMouseOut={onMouseOut}
+                onMouseLeave={onMouseLeave}
+                onMouseMove={onMouseMove}
+                onMouseOver={onMouseOver}
                 pathGenerator={pathGenerator}
                 selected={!!selectedLocationsMappedById[key]}
                 selectedClassName={pathSelectedClassName}
@@ -130,16 +130,16 @@ FeatureLayer.propTypes = {
   onClick: PropTypes.func,
 
   /* passed to each path; signature: function(event, locationId, Path) {...} */
-  onMouseOver: PropTypes.func,
+  onMouseDown: PropTypes.func,
+
+  /* passed to each path; signature: function(event, locationId, Path) {...} */
+  onMouseLeave: PropTypes.func,
 
   /* passed to each path; signature: function(event, locationId, Path) {...} */
   onMouseMove: PropTypes.func,
 
   /* passed to each path; signature: function(event, locationId, Path) {...} */
-  onMouseDown: PropTypes.func,
-
-  /* passed to each path; signature: function(event, locationId, Path) {...} */
-  onMouseOut: PropTypes.func,
+  onMouseOver: PropTypes.func,
 
   pathClassName: CommonPropTypes.className,
 

--- a/src/ui/choropleth/src/path.jsx
+++ b/src/ui/choropleth/src/path.jsx
@@ -128,7 +128,7 @@ Path.propTypes = {
   fill: PropTypes.string,
 
   /* locationId identifying this geometry */
-  locationId: PropTypes.number,
+  locationId: PropTypes.oneOfType(PropTypes.number, PropTypes.string),
 
   /* signature: function(event, locationId, Path) {...} */
   onClick: PropTypes.func,

--- a/src/ui/choropleth/src/path.jsx
+++ b/src/ui/choropleth/src/path.jsx
@@ -42,7 +42,7 @@ export default class Path extends PureComponent {
       'onClick',
       'onMouseDown',
       'onMouseMove',
-      'onMouseOut',
+      'onMouseLeave',
       'onMouseOver'
     ]);
   }
@@ -69,6 +69,13 @@ export default class Path extends PureComponent {
     this.props.onMouseDown(e, this.props.locationId, this);
   }
 
+  // e.g., destroy tooltip
+  onMouseLeave(e) {
+    e.preventDefault();
+
+    this.props.onMouseLeave(e, this.props.locationId, this);
+  }
+
   // e.g., position tooltip
   onMouseMove(e) {
     e.preventDefault();
@@ -76,13 +83,6 @@ export default class Path extends PureComponent {
     // set flag to prevent onClick handler from firing when map is being dragged
     this.dragging = true;
     this.props.onMouseMove(e, this.props.locationId, this);
-  }
-
-  // e.g., destroy tooltip
-  onMouseOut(e) {
-    e.preventDefault();
-
-    this.props.onMouseOut(e, this.props.locationId, this);
   }
 
   // e.g., init tooltip
@@ -105,8 +105,8 @@ export default class Path extends PureComponent {
         style={style}
         onClick={this.onClick}
         onMouseDown={this.onMouseDown}
+        onMouseLeave={this.onMouseLeave}
         onMouseMove={this.onMouseMove}
-        onMouseOut={this.onMouseOut}
         onMouseOver={this.onMouseOver}
       >
       </path>
@@ -137,16 +137,16 @@ Path.propTypes = {
   onClick: PropTypes.func,
 
   /* signature: function(event, locationId, Path) {...} */
-  onMouseOver: PropTypes.func,
+  onMouseDown: PropTypes.func,
+
+  /* signature: function(event, locationId, Path) {...} */
+  onMouseLeave: PropTypes.func,
 
   /* signature: function(event, locationId, Path) {...} */
   onMouseMove: PropTypes.func,
 
   /* signature: function(event, locationId, Path) {...} */
-  onMouseDown: PropTypes.func,
-
-  /* signature: function(event, locationId, Path) {...} */
-  onMouseOut: PropTypes.func,
+  onMouseOver: PropTypes.func,
 
   /* a function which accepts a `feature` and returns a valid `d` attribute */
   pathGenerator: PropTypes.func.isRequired,
@@ -166,10 +166,10 @@ Path.propTypes = {
 
 Path.defaultProps = {
   onClick: noop,
-  onMouseOver: noop,
-  onMouseMove: noop,
   onMouseDown: noop,
-  onMouseOut: noop,
+  onMouseLeave: noop,
+  onMouseMove: noop,
+  onMouseOver: noop,
   selected: false,
   selectedStyle: {
     strokeWidth: '2px',

--- a/src/ui/choropleth/src/path.jsx
+++ b/src/ui/choropleth/src/path.jsx
@@ -128,7 +128,10 @@ Path.propTypes = {
   fill: PropTypes.string,
 
   /* locationId identifying this geometry */
-  locationId: PropTypes.oneOfType(PropTypes.number, PropTypes.string),
+  locationId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 
   /* signature: function(event, locationId, Path) {...} */
   onClick: PropTypes.func,

--- a/src/ui/choropleth/test/path.test.js
+++ b/src/ui/choropleth/test/path.test.js
@@ -21,7 +21,7 @@ describe('Choropleth <Path />', () => {
   });
 
   describe('events', () => {
-    it(`calls onClick, mouseDown, mouseMove, mouseOut, and mouseOver 
+    it(`calls onClick, mouseDown, mouseMove, mouseLeave, and mouseOver 
     with event, locationId, and the React element`, () => {
       const wrapper = shallow(
         <Path
@@ -31,7 +31,7 @@ describe('Choropleth <Path />', () => {
           onClick={eventHandler}
           onMouseDown={eventHandler}
           onMouseMove={eventHandler}
-          onMouseOut={eventHandler}
+          onMouseLeave={eventHandler}
           onMouseOver={eventHandler}
         />
       );
@@ -41,7 +41,7 @@ describe('Choropleth <Path />', () => {
       };
 
       const inst = wrapper.instance();
-      ['click', 'mouseDown', 'mouseMove', 'mouseOut', 'mouseOver'].forEach((evtName) => {
+      ['click', 'mouseDown', 'mouseMove', 'mouseLeave', 'mouseOver'].forEach((evtName) => {
         eventHandler.reset();
         wrapper.simulate(evtName, event);
         expect(eventHandler.calledOnce).to.be.true;


### PR DESCRIPTION
- Add clip extent to `<Choropleth />`'s path generator as an easy-win (huge) performance enhancement.
- Change `<Choropleth />` prop name 'geoJSONKeyField' to 'geometryKeyField' so that it makes more sense. Also, change it to more accurately reflect that it accepts but a string and a function.
- Change `<Path />` prop 'locationId' to accept both a string and a number, because we have a use-case for both.