### PR TITLE
Enhancement/spinner style

### DIFF
--- a/src/ui/spinner/demo/app.jsx
+++ b/src/ui/spinner/demo/app.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { PureComponent } from '../../../utils';
+
+import Spinner from '../';
+
+class App extends PureComponent {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        <Spinner style={{ fontSize: 'medium' }} />
+      </div>
+    )
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/src/ui/spinner/demo/html-pre-tag-loader.js
+++ b/src/ui/spinner/demo/html-pre-tag-loader.js
@@ -1,0 +1,24 @@
+const blockLoader = require('block-loader');
+
+const startPre = '<pre><code>';
+const endPre = '</code></pre>';
+
+const options = {
+  start: `{/* ${startPre}`,
+  end: `${endPre} */}`,
+  process: function fixBlocks(block) {
+    const replaced = block
+      .replace(options.start, '')   // first, remove the start/end delimiters, then:
+      .replace(options.end, '')     //
+      .replace(/&/g, '&amp;')       // 1. use html entity equivalent,
+      .replace(/</g, '&lt;')        // 2. use html entity equivalent,
+      .replace(/>/g, '&gt;')        // 3. use html entity equivalent,
+      .replace(/([{}])/g, "{'$1'}") // 4. JSX-safify curly braces,
+      .replace(/\n/g, "{'\\n'}");   // 5. and preserve line endings, thanks.
+
+    // done! return with the delimiters put back in place
+    return `${startPre}${replaced}${endPre}`;
+  },
+};
+
+module.exports = blockLoader(options);

--- a/src/ui/spinner/demo/index.html
+++ b/src/ui/spinner/demo/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Group Demo</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
+  <style>
+    html, body {
+      box-sizing: border-box;
+    }
+
+    body {
+      display: flex;
+      width: 100%;
+      height: 100%;
+    }
+
+    #app {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    section {
+      margin-bottom: 25px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid black;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
+
+    pre {
+      background-color: cornsilk;
+    }
+  </style>
+</head>
+<body>
+    <main id="app"></main>
+
+<script src="../../../../node_modules/babel-polyfill/dist/polyfill.js"></script>
+<script src="bundle.js"></script>
+</body>
+</html>

--- a/src/ui/spinner/demo/webpack.config.js
+++ b/src/ui/spinner/demo/webpack.config.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var path = require('path');
+var autoprefixer = require('autoprefixer');
+var WebpackNotifierPlugin = require('webpack-notifier');
+
+module.exports = {
+  devtool: 'source-map',
+  context: __dirname,
+  entry: './app',
+  output: {
+    path: __dirname,
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new WebpackNotifierPlugin({alwaysNotify: true})
+  ],
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: 'node-modules/',
+        loaders: ['babel', __dirname + '/html-pre-tag-loader']
+      },
+      {
+        test: /\.css$/,
+        loader: 'style!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader'
+      },
+    ]
+  },
+  postcss: [autoprefixer],
+  resolve: {
+    extensions: ['', '.js', '.jsx']
+  },
+  progress: true
+};

--- a/src/ui/spinner/src/spinner.css
+++ b/src/ui/spinner/src/spinner.css
@@ -17,45 +17,28 @@
 }
 
 .dot {
-  background-color: #333;
   border-radius: 50%;
   display: inline-block;
-  animation: bouncedelay 1200ms infinite ease-in-out;
+  animation: bouncedelay 900ms infinite ease-in-out;
   animation-fill-mode: both;
+  width: 1em;
+  height: 1em;
 }
 
 .dot:nth-child(2n) {
-  animation-delay: 180ms;
+  animation-delay: 200ms;
   margin-left: 1em;
 }
 
 .dot:nth-child(3n) {
-  animation-delay: 360ms;
+  animation-delay: 400ms;
   margin-left: 1em;
 }
 
-.small-dot {
-  composes: dot;
-  width: 0.3vw;
-  height: 0.3vw;
-}
-
-.medium-dot {
-  composes: dot;
-  width: 1vw;
-  height: 1vw;
-}
-
-.large-dot {
-  composes: dot;
-  width: 2vw;
-  height: 2vw;
-}
-
 @keyframes bouncedelay {
-  0%, 80%, 100% {
-    transform: scale(0.0);
-  } 40% {
-      transform: scale(1.0);
+  0%, 50%, 100% {
+    transform: scale(1.0);
+  } 20% {
+      transform: scale(2.0);
   }
 }

--- a/src/ui/spinner/src/spinner.jsx
+++ b/src/ui/spinner/src/spinner.jsx
@@ -7,22 +7,30 @@ import styles from './spinner.css';
 
 class Spinner extends PureComponent {
   render() {
-    const { props } = this;
+    const {
+      className,
+      inline,
+      style,
+      symbolFill,
+      symbolStyle,
+      symbolType,
+    } = this.props;
+
     return (
       <div
         className={classNames(styles.spinner, {
-          [styles['inline-spinner']]: props.inline
-        }, props.className)}
-        style={props.style}
+          [styles['inline-spinner']]: inline
+        }, className)}
+        style={style}
       >
         <svg className={styles.dot} viewBox="-8 -8 16 16" width="1em" height="1em">
-          <Symbol symbolType="circle" fill="black" />
+          <Symbol fill={symbolFill} style={symbolStyle} symbolType={symbolType} />
         </svg>
         <svg className={styles.dot} viewBox="-8 -8 16 16" width="1em" height="1em">
-          <Symbol symbolType="circle" fill="black" />
+          <Symbol fill={symbolFill} style={symbolStyle} symbolType={symbolType} />
         </svg>
         <svg className={styles.dot} viewBox="-8 -8 16 16" width="1em" height="1em">
-          <Symbol symbolType="circle" fill="black" />
+          <Symbol fill={symbolFill} style={symbolStyle} symbolType={symbolType} />
         </svg>
       </div>
     );
@@ -37,6 +45,15 @@ Spinner.propTypes = {
   inline: PropTypes.bool,
 
   style: CommonPropTypes.style,
+
+  symbolFill: PropTypes.string,
+  symbolStyle: CommonPropTypes.style,
+  symbolType: PropTypes.string,
+};
+
+Spinner.defaultProps = {
+  symbolFill: 'black',
+  symbolType: 'circle',
 };
 
 export default Spinner;

--- a/src/ui/spinner/src/spinner.jsx
+++ b/src/ui/spinner/src/spinner.jsx
@@ -1,37 +1,42 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { Symbol } from '../../shape';
+import { CommonPropTypes, PureComponent } from '../../../utils';
 
 import styles from './spinner.css';
 
-const propTypes = {
+class Spinner extends PureComponent {
+  render() {
+    const { props } = this;
+    return (
+      <div
+        className={classNames(styles.spinner, {
+          [styles['inline-spinner']]: props.inline
+        }, props.className)}
+        style={props.style}
+      >
+        <svg className={styles.dot} viewBox="-8 -8 16 16" width="1em" height="1em">
+          <Symbol symbolType="circle" fill="black" />
+        </svg>
+        <svg className={styles.dot} viewBox="-8 -8 16 16" width="1em" height="1em">
+          <Symbol symbolType="circle" fill="black" />
+        </svg>
+        <svg className={styles.dot} viewBox="-8 -8 16 16" width="1em" height="1em">
+          <Symbol symbolType="circle" fill="black" />
+        </svg>
+      </div>
+    );
+  }
+}
+
+Spinner.propTypes = {
+  /* an extra classname */
+  className: CommonPropTypes.className,
+
   /* display spinner inline with other elements (e.g., in a button) */
   inline: PropTypes.bool,
 
-  /* how large the dots will be */
-  size: PropTypes.oneOf(['small', 'medium', 'large']),
-
-  /* an extra classname */
-  className: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.array,
-    PropTypes.object
-  ])
+  style: CommonPropTypes.style,
 };
-
-const Spinner = (props) => {
-  return (
-    <div
-      className={classNames(styles.spinner, {
-        [styles['inline-spinner']]: props.inline
-      }, props.className)}
-    >
-      <span className={styles[`${props.size}-dot`]}></span>
-      <span className={styles[`${props.size}-dot`]}></span>
-      <span className={styles[`${props.size}-dot`]}></span>
-    </div>
-  );
-};
-
-Spinner.propTypes = propTypes;
 
 export default Spinner;

--- a/src/ui/spinner/test/spinner.test.js
+++ b/src/ui/spinner/test/spinner.test.js
@@ -13,7 +13,7 @@ describe('<Spinner />', () => {
     const wrapper = shallow(<Spinner />);
     expect(wrapper).to.have.length(1);
     expect(wrapper).to.have.tagName('div');
-    expect(wrapper).to.have.exactly(3).descendants('span');
+    expect(wrapper).to.have.exactly(3).descendants('svg');
   });
 
   it('renders inline', () => {


### PR DESCRIPTION
This is a style update, kind of fresh. 
Uses `svg` instead of `span`. Adds style prop. Size of spinner is determined by `font-size` style now, not `size` prop and `vw`. This makes it more consistently sized in different views.
