### PR TITLE
add clipPath prop to axisChart

### DIFF
--- a/src/ui/axis-chart/src/axis-chart.jsx
+++ b/src/ui/axis-chart/src/axis-chart.jsx
@@ -63,7 +63,7 @@ export default class AxisChart extends React.Component {
   render() {
     const { props } = this;
     const { chartDimensions, scales } = this.state;
-    const clipPathId = uniqueId('chartClip');
+    const clipPathId = uniqueId('chartClip_');
 
     return (
       <svg

--- a/src/ui/axis-chart/src/axis-chart.jsx
+++ b/src/ui/axis-chart/src/axis-chart.jsx
@@ -63,7 +63,7 @@ export default class AxisChart extends React.Component {
   render() {
     const { props } = this;
     const { chartDimensions, scales } = this.state;
-    const clipPathId = uniqueId();
+    const clipPathId = uniqueId('chartClip');
 
     return (
       <svg

--- a/src/ui/axis-chart/src/axis-chart.jsx
+++ b/src/ui/axis-chart/src/axis-chart.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { uniqueId } from 'lodash';
 import classNames from 'classnames';
 import { CommonPropTypes, getScale, getScaleTypes, propsChanged } from '../../../utils';
 
@@ -62,6 +63,7 @@ export default class AxisChart extends React.Component {
   render() {
     const { props } = this;
     const { chartDimensions, scales } = this.state;
+    const clipPathId = uniqueId();
 
     return (
       <svg
@@ -69,12 +71,24 @@ export default class AxisChart extends React.Component {
         height={`${chartDimensions.height + props.padding.bottom + props.padding.top}px`}
         className={classNames(props.className)}
       >
+        {props.clipPath ? (<defs>
+          <clipPath id={clipPathId}>
+            <rect
+              width={`${chartDimensions.width}px`}
+              height={`${chartDimensions.height}px`}
+            >
+            </rect>
+          </clipPath>
+        </defs>)
+        : null
+      }
         <g transform={`translate(${props.padding.left}, ${props.padding.top})`}>
            {
              React.Children.map(props.children, (child) => {
                return child && React.cloneElement(child, {
                  scales,
                  padding: props.padding,
+                 clipPathId: props.clipPath ? clipPathId : (void 0),
                  ...chartDimensions,
                });
              })
@@ -88,6 +102,9 @@ export default class AxisChart extends React.Component {
 AxisChart.propTypes = {
   /* class names to appended to the element */
   className: CommonPropTypes.className,
+
+  /* use clip path in children */
+  clipPath: PropTypes.bool,
 
   /* [min, max] for xScale (i.e., the domain of the data) */
   xDomain: PropTypes.array,

--- a/src/ui/axis-chart/test/axis-chart.test.js
+++ b/src/ui/axis-chart/test/axis-chart.test.js
@@ -35,6 +35,7 @@ describe('<AxisChart />', () => {
         yScaleType="linear"
         width={800}
         height={600}
+        clipPath
       >
         {
           map(lineData, (dataSet) => {
@@ -63,6 +64,13 @@ describe('<AxisChart />', () => {
       .to.have.prop('scales')
       .that.is.an('object')
       .that.has.keys(['x', 'y']);
+  });
+
+  it('passes clip-path id to child components', () => {
+    const wrapper = shallow(component);
+    expect(wrapper.find('p').first())
+      .to.have.prop('clipPathId')
+      .that.is.a('string');
   });
 
   describe('updates based on new props', () => {

--- a/src/ui/shape/src/area.jsx
+++ b/src/ui/shape/src/area.jsx
@@ -26,6 +26,7 @@ export default class Area extends PureComponent {
   render() {
     const {
       className,
+      clipPathId,
       data,
       onClick,
       onMouseLeave,
@@ -41,6 +42,7 @@ export default class Area extends PureComponent {
     return (
       <path
         className={className && classNames(className)}
+        clipPath={`url(#${clipPathId})`}
         d={path}
         onClick={eventHandleWrapper(onClick, data, this)}
         onMouseLeave={eventHandleWrapper(onMouseLeave, data, this)}
@@ -54,6 +56,9 @@ export default class Area extends PureComponent {
 
 Area.propTypes = {
   className: CommonPropTypes.className,
+
+  /* string id url for clip path */
+  clipPathId: PropTypes.string,
 
   /* array of objects. e.g. [ {}, {}, {} ] */
   data: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/ui/shape/src/area.jsx
+++ b/src/ui/shape/src/area.jsx
@@ -42,7 +42,7 @@ export default class Area extends PureComponent {
     return (
       <path
         className={className && classNames(className)}
-        clipPath={`url(#${clipPathId})`}
+        clipPath={clipPathId && `url(#${clipPathId})`}
         d={path}
         onClick={eventHandleWrapper(onClick, data, this)}
         onMouseLeave={eventHandleWrapper(onMouseLeave, data, this)}

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -26,6 +26,7 @@ export default class Line extends PureComponent {
   render() {
     const {
       className,
+      clipPathId,
       data,
       onClick,
       onMouseLeave,
@@ -41,6 +42,7 @@ export default class Line extends PureComponent {
     return (
       <path
         className={className && classNames(className)}
+        clipPath={`url(#${clipPathId})`}
         d={path}
         fill="none"
         onClick={eventHandleWrapper(onClick, data, this)}
@@ -56,6 +58,9 @@ export default class Line extends PureComponent {
 Line.propTypes = {
   /* base classname to apply to line */
   className: CommonPropTypes.className,
+
+  /* string id url for clip path */
+  clipPathId: PropTypes.string,
 
   /* array of objects. e.g. [ {}, {}, {} ] */
   data: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -42,7 +42,7 @@ export default class Line extends PureComponent {
     return (
       <path
         className={className && classNames(className)}
-        clipPath={`url(#${clipPathId})`}
+        clipPath={clipPathId && `url(#${clipPathId})`}
         d={path}
         fill="none"
         onClick={eventHandleWrapper(onClick, data, this)}

--- a/src/ui/shape/src/multi-line.jsx
+++ b/src/ui/shape/src/multi-line.jsx
@@ -38,7 +38,7 @@ export default class MultiLine extends PureComponent {
       <g
         className={className && classNames(className)}
         style={style}
-        clipPath={`url(#${clipPathId})`}
+        clipPath={clipPathId && `url(#${clipPathId})`}
       >
         {
           map(data, (datum) => {

--- a/src/ui/shape/src/multi-line.jsx
+++ b/src/ui/shape/src/multi-line.jsx
@@ -14,6 +14,7 @@ export default class MultiLine extends PureComponent {
       areaStyle,
       areaValuesIteratee,
       className,
+      clipPathId,
       colorScale,
       data,
       dataAccessors,
@@ -34,7 +35,11 @@ export default class MultiLine extends PureComponent {
     ]);
 
     return (
-      <g className={className && classNames(className)} style={style}>
+      <g
+        className={className && classNames(className)}
+        style={style}
+        clipPath={`url(#${clipPathId})`}
+      >
         {
           map(data, (datum) => {
             const key = propResolver(datum, keyField);
@@ -101,6 +106,9 @@ MultiLine.propTypes = {
   colorScale: PropTypes.func,
 
   className: CommonPropTypes.className,
+
+  /* string id url for clip path */
+  clipPathId: PropTypes.string,
 
   /* array of objects
     e.g. [ {location: 'USA',values: []}, {location: 'Canada', values: []} ]

--- a/src/ui/shape/src/multi-scatter.jsx
+++ b/src/ui/shape/src/multi-scatter.jsx
@@ -36,7 +36,7 @@ export default function MultiScatter(props) {
   ]);
 
   return (
-    <g className={classNames(className) || (void 0)} clipPath={`url(#${clipPathId})`}>
+    <g className={classNames(className) || (void 0)} clipPath={clipPathId && `url(#${clipPathId})`}>
       {
         map(data, (scatterData) => {
           const key = scatterData[keyField];

--- a/src/ui/shape/src/multi-scatter.jsx
+++ b/src/ui/shape/src/multi-scatter.jsx
@@ -7,6 +7,7 @@ import Scatter from './scatter';
 export default function MultiScatter(props) {
   const {
     className,
+    clipPathId,
     colorScale,
     data,
     dataField,
@@ -35,7 +36,7 @@ export default function MultiScatter(props) {
   ]);
 
   return (
-    <g className={classNames(className) || (void 0)}>
+    <g className={classNames(className) || (void 0)} clipPath={`url(#${clipPathId})`}>
       {
         map(data, (scatterData) => {
           const key = scatterData[keyField];
@@ -63,6 +64,9 @@ export default function MultiScatter(props) {
 MultiScatter.propTypes = {
   /* base classname to apply to mult-scatter <g> wrapper */
   className: CommonPropTypes.className,
+
+  /* string id url for clip path */
+  clipPathId: PropTypes.string,
 
   /* function for a scale of colors. If present, overrides fill */
   colorScale: PropTypes.func,

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -58,7 +58,7 @@ export default class Scatter extends PureComponent {
     ]);
 
     return (
-      <g className={className && classNames(className)} clipPath={`url(#${clipPathId})`}>
+      <g className={className && classNames(className)} clipPath={clipPathId && `url(#${clipPathId})`}>
         {
           map(sortedData, (plotDatum) => {
             // value passed into colorScale

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -58,7 +58,10 @@ export default class Scatter extends PureComponent {
     ]);
 
     return (
-      <g className={className && classNames(className)} clipPath={clipPathId && `url(#${clipPathId})`}>
+      <g
+        className={className && classNames(className)}
+        clipPath={clipPathId && `url(#${clipPathId})`}
+      >
         {
           map(sortedData, (plotDatum) => {
             // value passed into colorScale

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -33,6 +33,7 @@ export default class Scatter extends PureComponent {
   render() {
     const {
       className,
+      clipPathId,
       colorScale,
       dataAccessors,
       fill,
@@ -57,7 +58,7 @@ export default class Scatter extends PureComponent {
     ]);
 
     return (
-      <g className={className && classNames(className)}>
+      <g className={className && classNames(className)} clipPath={`url(#${clipPathId})`}>
         {
           map(sortedData, (plotDatum) => {
             // value passed into colorScale
@@ -94,6 +95,9 @@ export default class Scatter extends PureComponent {
 Scatter.propTypes = {
   /* base classname to apply to scatter <g> wrapper */
   className: CommonPropTypes.className,
+
+  /* string id url for clip path */
+  clipPathId: PropTypes.string,
 
   /* function for a scale of colors. If present, overrides fill */
   colorScale: PropTypes.func,

--- a/src/ui/shape/src/symbol.jsx
+++ b/src/ui/shape/src/symbol.jsx
@@ -80,6 +80,7 @@ export default class Symbol extends PureComponent {
   render() {
     const {
       className,
+      clipPathId,
       datum,
       focused,
       focusedClassName,
@@ -101,6 +102,7 @@ export default class Symbol extends PureComponent {
           [selectedClassName]: selected && selectedClassName,
           [focusedClassName]: focused && selectedClassName,
         }) || (void 0)}
+        clipPath={`url(#${clipPathId})`}
         onClick={eventHandleWrapper(onClick, datum, this)}
         onMouseLeave={eventHandleWrapper(onMouseLeave, datum, this)}
         onMouseMove={eventHandleWrapper(onMouseMove, datum, this)}
@@ -115,6 +117,9 @@ export default class Symbol extends PureComponent {
 Symbol.propTypes = {
   /* base classname to apply to symbol */
   className: CommonPropTypes.className,
+
+  /* string id url for clip path */
+  clipPathId: PropTypes.string,
 
   /* Datum for the click and hover handlers. */
   datum: PropTypes.object,

--- a/src/ui/shape/src/symbol.jsx
+++ b/src/ui/shape/src/symbol.jsx
@@ -102,7 +102,7 @@ export default class Symbol extends PureComponent {
           [selectedClassName]: selected && selectedClassName,
           [focusedClassName]: focused && selectedClassName,
         }) || (void 0)}
-        clipPath={`url(#${clipPathId})`}
+        clipPath={clipPathId && `url(#${clipPathId})`}
         onClick={eventHandleWrapper(onClick, datum, this)}
         onMouseLeave={eventHandleWrapper(onMouseLeave, datum, this)}
         onMouseMove={eventHandleWrapper(onMouseMove, datum, this)}


### PR DESCRIPTION
These changes give axis-chart a new prop `clipPath [boolean]` that can implement a `<defs>` containing a rectangular clipPath with width and height of the chart display area. Thus if a line, area, or symbol extends outside the clipPath, it is not painted on the svg (use case is for scaling axes, changing domain or range).

Shape components all receive a `clipPathId [string]` prop that is used by the primitive component to access the clipPath. 