### PR TITLE
enhancement/number formatter

### DIFF
--- a/src/utils/numbers.js
+++ b/src/utils/numbers.js
@@ -4,11 +4,12 @@ import { isFinite } from 'lodash';
  * number formatter to be used as, for example, tickFormat fn and label formatter
  * if value is a non-finite number, returns empty string
  * @param {number} value
+ * @param {number} [precision] defaults to three decimal places
  * @return {string}
  */
-export function numberFormat(value) {
+export function numberFormat(value, precision = 3) {
   if (!isFinite(value)) return '';
-  if (value >= 1000) return `${(value / 1000).toFixed(3)}k`;
-  if (value <= 0.01) return value.toExponential(3);
-  return value.toFixed(2);
+  if (value >= 1000) return `${(value / 1000).toFixed(precision)}k`;
+  if (value <= 0.01) return value.toExponential(precision);
+  return value.toFixed(precision);
 }

--- a/src/utils/test/numbers.test.js
+++ b/src/utils/test/numbers.test.js
@@ -15,11 +15,17 @@ describe('Number utilities', () => {
       expect(numberFormat(0.005836)).to.equal('5.836e-3');
     });
 
-    it('displays all 0.001 > values < 1000 to hundredths precision', () => {
-      expect(numberFormat(1)).to.equal('1.00');
-      expect(numberFormat(15)).to.equal('15.00');
-      expect(numberFormat(0.239745)).to.equal('0.24');
-      expect(numberFormat(28.123456)).to.equal('28.12');
+    it('displays all 0.001 > values < 1000 to thousandths precision by default', () => {
+      expect(numberFormat(1)).to.equal('1.000');
+      expect(numberFormat(15)).to.equal('15.000');
+      expect(numberFormat(0.239745)).to.equal('0.240');
+      expect(numberFormat(28.123456)).to.equal('28.123');
+    });
+
+    it('can accept an alternate precision', () => {
+      expect(numberFormat(5432.35784, 1)).to.equal('5.4k');
+      expect(numberFormat(0.239745, 5)).to.equal('0.23975');
+      expect(numberFormat(0.01, 2)).to.equal('1.00e-2');
     });
   });
 });

--- a/src/utils/test/numbers.test.js
+++ b/src/utils/test/numbers.test.js
@@ -15,7 +15,7 @@ describe('Number utilities', () => {
       expect(numberFormat(0.005836)).to.equal('5.836e-3');
     });
 
-    it('displays all 0.001 > values < 1000 to thousandths precision by default', () => {
+    it('displays all 0.01 > values < 1000 to thousandths precision by default', () => {
       expect(numberFormat(1)).to.equal('1.000');
       expect(numberFormat(15)).to.equal('15.000');
       expect(numberFormat(0.239745)).to.equal('0.240');


### PR DESCRIPTION
default to formatting numbers to the thousandths place, but now accept a precision parameter
