### PR TITLE
Fix choropleth legend scale

### DIFF
--- a/src/ui/choropleth-legend/src/choropleth-legend.jsx
+++ b/src/ui/choropleth-legend/src/choropleth-legend.jsx
@@ -287,7 +287,7 @@ ChoroplethLegend.propUpdates = {
     if (xScale.clamp) xScale.clamp(true);
     return assign({}, state, {
       adjustedWidth,
-      scatterScaleMap: { x: xScale },
+      scatterScaleMap: { x: xScale.copy() },
       sliderScale: state.sliderScale.domain(nextProps.domain).range([0, adjustedWidth]),
     });
   },


### PR DESCRIPTION
Send a copy of the scale to the axis to ensure that the ticks are updated when the legend domain is updated