### PR TITLE
Multiline scales

### DIFF
--- a/src/ui/shape/src/multi-scatter.jsx
+++ b/src/ui/shape/src/multi-scatter.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { scaleLinear } from 'd3';
 import { castArray, map, pick } from 'lodash';
 import Scatter from './scatter';
 
@@ -202,6 +203,7 @@ MultiScatter.defaultProps = {
     data: 'values',
     key: 'key',
   },
+  scales: { x: scaleLinear(), y: scaleLinear() },
   scatterValuesIteratee: CommonDefaultProps.identity,
   size: 64,
   symbolField: 'type',

--- a/src/ui/shape/src/multi-scatter.jsx
+++ b/src/ui/shape/src/multi-scatter.jsx
@@ -147,7 +147,7 @@ MultiScatter.propTypes = {
   scales: PropTypes.shape({
     x: PropTypes.func,
     y: PropTypes.func,
-  }).isRequired,
+  }),
 
   /*
    classname to apply to Scatter's <g> wrapper;

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -147,7 +147,7 @@ Scatter.propTypes = {
   scales: PropTypes.shape({
     x: PropTypes.func,
     y: PropTypes.func,
-  }).isRequired,
+  }),
 
   /* a symbol that is selected, or an array of symbols selected */
   selection: PropTypes.array,

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import { scaleLinear } from 'd3';
 import {
   assign,
   findIndex,
@@ -171,6 +172,7 @@ Scatter.defaultProps = {
   onMouseLeave: CommonDefaultProps.noop,
   onMouseMove: CommonDefaultProps.noop,
   onMouseOver: CommonDefaultProps.noop,
+  scales: { x: scaleLinear(), y: scaleLinear() },
   size: 64,
   symbolType: 'circle',
 };


### PR DESCRIPTION
A fix to #86. Setting defaultProps for scales removes warnings when AxisChart passes scales. Unfortunately, since scales is a required prop, a console warning won't show up if scales are not passed in other instances. If scales has a defaultProp, should scales be a required prop still? 