### PR TITLE
Merge single multi select

### DIFF
--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -9,7 +9,11 @@ import Group, { Option } from './group';
 import HtmlLabel from './html-label';
 import Legend from './legend';
 import ResponsiveContainer from './responsive-container';
-import { SingleSelect, MultiSelect } from './select';
+import {
+  MultiSelect,
+  Select,
+  SingleSelect,
+} from './select';
 import {
   Area,
   Line,
@@ -43,6 +47,7 @@ export {
   Option,
   ResponsiveContainer,
   Scatter,
+  Select,
   SingleSelect,
   Slider,
   Spinner,

--- a/src/ui/select/demo/app.jsx
+++ b/src/ui/select/demo/app.jsx
@@ -176,6 +176,7 @@ class App extends React.Component {
          multiSelect
          labelKey="name"
          valueKey="name"
+         placeholder="select cities"
          onChange={ function (selections <Array>) {...} }
          options={ [{name: 'Albany'}, ...] }
          value={[]}
@@ -200,6 +201,7 @@ class App extends React.Component {
        <Select
          labelKey="name"
          valueKey="name"
+         placeholder="select city"
          onChange={ function (selections <Object>) {...} }
          options={ [{name: 'Albany'}, ...] }
          value={null}

--- a/src/ui/select/demo/app.jsx
+++ b/src/ui/select/demo/app.jsx
@@ -60,46 +60,46 @@ class App extends React.Component {
           <h3>Multi-select</h3>
 {/* <pre><code>
      <Select
-       multiSelect
        labelKey="name"
-       valueKey="name"
+       multi
        onChange={ function (selections <Array>) {...} }
        options={ [{name: 'Albany'}, ...] }
        value={[]}
+       valueKey="name"
      />
 
 </code></pre> */}
           <Select
-            multiSelect
             labelKey="name"
-            valueKey="name"
+            multi
             onChange={this.onMultiSelectChange}
             options={cities}
             value={multiSelectValues}
+            valueKey="name"
           />
         </section>
         <section>
           <h3>Hierarchical multi-select</h3>
 {/* <pre><code>
      <Select
-       multiSelect
        hierarchical
        labelKey="name"
-       valueKey="name"
+       multi
        onChange={ function (selections <Array>) {...} }
        options={ [{ name: 'Albany', level: 1, bold: true }, ...] }
        value={[]}
+       valueKey="name"
      />
 
 </code></pre> */}
           <Select
-            multiSelect
             hierarchical
             labelKey="name"
-            valueKey="name"
+            multi
             onChange={this.onMultiSelectChange}
             options={hierarchicalCities}
             value={multiSelectValues}
+            valueKey="name"
           />
         </section>
         <section>
@@ -107,19 +107,19 @@ class App extends React.Component {
 {/* <pre><code>
      <Select
        labelKey="name"
-       valueKey="name"
        onChange={ function (selections <Object>) {...} }
        options={ [{name: 'Albany'}, ...] }
        value={null}
+       valueKey="name"
      />
 
 </code></pre> */}
           <Select
             labelKey="name"
-            valueKey="name"
             onChange={this.onSingleSelectChange}
             options={cities}
             value={singleSelectValue}
+            valueKey="name"
           />
         </section>
         <section>
@@ -128,20 +128,20 @@ class App extends React.Component {
      <Select
        hierarchical
        labelKey="name"
-       valueKey="name"
        onChange={ function (selections <Object>) {...} }
        options={ [{ name: 'Albany', level: 1, bold: true }, ...] }
        value={null}
+       valueKey="name"
      />
 
 </code></pre> */}
           <Select
             hierarchical
             labelKey="name"
-            valueKey="name"
             onChange={this.onSingleSelectChange}
             options={hierarchicalCities}
             value={singleSelectValue}
+            valueKey="name"
           />
         </section>
 
@@ -151,48 +151,48 @@ class App extends React.Component {
        <Select
          hierarchical
          labelKey="name"
-         valueKey="name"
          onChange={ function (selections <Object>) {...} }
          options={ [{ name: 'Albany', level: 1, bold: true }, ...] }
          optionStyle={function(option) {...}}
          value={null}
+         valueKey="name"
        />
 
 </code></pre> */}
           <Select
             hierarchical
             labelKey="name"
-            valueKey="name"
             onChange={this.onSingleSelectChange}
             options={hierarchicalCities}
             optionStyle={randomlyDisableOptions}
             value={singleSelectValue}
+            valueKey="name"
           />
         </section>
         <section>
           <h3>Multi-select flip up</h3>
 {/* <pre><code>
-       <MultiSelect
-         multiSelect
+       <Select
          labelKey="name"
-         valueKey="name"
-         placeholder="select cities"
+         menuUpward
+         multi
          onChange={ function (selections <Array>) {...} }
          options={ [{name: 'Albany'}, ...] }
+         placeholder="select cities"
          value={[]}
-         menuUpward
+         valueKey="name"
        />
 
  </code></pre> */}
           <Select
-            multiSelect
             labelKey="name"
-            valueKey="name"
+            menuUpward
+            multi
             onChange={this.onMultiSelectChange}
             options={cities}
-            value={multiSelectValues}
             placeholder="select cities"
-            menuUpward
+            value={multiSelectValues}
+            valueKey="name"
           />
         </section>
         <section>
@@ -200,23 +200,23 @@ class App extends React.Component {
 {/* <pre><code>
        <Select
          labelKey="name"
-         valueKey="name"
-         placeholder="select city"
+         menuUpward
          onChange={ function (selections <Object>) {...} }
          options={ [{name: 'Albany'}, ...] }
+         placeholder="select city"
          value={null}
-         menuUpward
+         valueKey="name"
        />
 
 </code></pre> */}
           <Select
             labelKey="name"
-            valueKey="name"
-            placeholder="select city"
+            menuUpward
             onChange={this.onSingleSelectChange}
             options={cities}
+            placeholder="select city"
             value={singleSelectValue}
-            menuUpward
+            valueKey="name"
           />
         </section>
       </div>

--- a/src/ui/select/demo/app.jsx
+++ b/src/ui/select/demo/app.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import { bindAll } from 'lodash';
 import { randomUniform } from 'd3';
 
-import { MultiSelect, SingleSelect } from '../';
+import { Select } from '../';
 import { default as cities } from './cities';
 import style from './app.css';
 
@@ -59,7 +59,8 @@ class App extends React.Component {
         <section>
           <h3>Multi-select</h3>
 {/* <pre><code>
-     <MultiSelect
+     <Select
+       multiSelect
        labelKey="name"
        valueKey="name"
        onChange={ function (selections <Array>) {...} }
@@ -68,7 +69,8 @@ class App extends React.Component {
      />
 
 </code></pre> */}
-          <MultiSelect
+          <Select
+            multiSelect
             labelKey="name"
             valueKey="name"
             onChange={this.onMultiSelectChange}
@@ -79,7 +81,8 @@ class App extends React.Component {
         <section>
           <h3>Hierarchical multi-select</h3>
 {/* <pre><code>
-     <MultiSelect
+     <Select
+       multiSelect
        hierarchical
        labelKey="name"
        valueKey="name"
@@ -89,7 +92,8 @@ class App extends React.Component {
      />
 
 </code></pre> */}
-          <MultiSelect
+          <Select
+            multiSelect
             hierarchical
             labelKey="name"
             valueKey="name"
@@ -101,7 +105,7 @@ class App extends React.Component {
         <section>
           <h3>Single-select</h3>
 {/* <pre><code>
-     <SingleSelect
+     <Select
        labelKey="name"
        valueKey="name"
        onChange={ function (selections <Object>) {...} }
@@ -110,7 +114,7 @@ class App extends React.Component {
      />
 
 </code></pre> */}
-          <SingleSelect
+          <Select
             labelKey="name"
             valueKey="name"
             onChange={this.onSingleSelectChange}
@@ -121,7 +125,7 @@ class App extends React.Component {
         <section>
           <h3>Hierarchical single-select</h3>
 {/* <pre><code>
-     <SingleSelect
+     <Select
        hierarchical
        labelKey="name"
        valueKey="name"
@@ -131,7 +135,7 @@ class App extends React.Component {
      />
 
 </code></pre> */}
-          <SingleSelect
+          <Select
             hierarchical
             labelKey="name"
             valueKey="name"
@@ -144,7 +148,7 @@ class App extends React.Component {
         <section>
           <h3>Option styling</h3>
 {/* <pre><code>
-       <SingleSelect
+       <Select
          hierarchical
          labelKey="name"
          valueKey="name"
@@ -155,7 +159,7 @@ class App extends React.Component {
        />
 
 </code></pre> */}
-          <SingleSelect
+          <Select
             hierarchical
             labelKey="name"
             valueKey="name"
@@ -167,18 +171,20 @@ class App extends React.Component {
         </section>
         <section>
           <h3>Multi-select flip up</h3>
-          {/* <pre><code>
-           <MultiSelect
-           labelKey="name"
-           valueKey="name"
-           onChange={ function (selections <Array>) {...} }
-           options={ [{name: 'Albany'}, ...] }
-           value={[]}
-           menuUpward
-           />
+{/* <pre><code>
+       <MultiSelect
+         multiSelect
+         labelKey="name"
+         valueKey="name"
+         onChange={ function (selections <Array>) {...} }
+         options={ [{name: 'Albany'}, ...] }
+         value={[]}
+         menuUpward
+       />
 
-           </code></pre> */}
-          <MultiSelect
+ </code></pre> */}
+          <Select
+            multiSelect
             labelKey="name"
             valueKey="name"
             onChange={this.onMultiSelectChange}
@@ -190,7 +196,7 @@ class App extends React.Component {
         <section>
           <h3>Single-select flip up</h3>
 {/* <pre><code>
-       <SingleSelect
+       <Select
          labelKey="name"
          valueKey="name"
          onChange={ function (selections <Object>) {...} }
@@ -200,7 +206,7 @@ class App extends React.Component {
        />
 
 </code></pre> */}
-          <SingleSelect
+          <Select
             labelKey="name"
             valueKey="name"
             onChange={this.onSingleSelectChange}

--- a/src/ui/select/demo/app.jsx
+++ b/src/ui/select/demo/app.jsx
@@ -190,6 +190,7 @@ class App extends React.Component {
             onChange={this.onMultiSelectChange}
             options={cities}
             value={multiSelectValues}
+            placeholder="select cities"
             menuUpward
           />
         </section>
@@ -209,6 +210,7 @@ class App extends React.Component {
           <Select
             labelKey="name"
             valueKey="name"
+            placeholder="select city"
             onChange={this.onSingleSelectChange}
             options={cities}
             value={singleSelectValue}

--- a/src/ui/select/index.js
+++ b/src/ui/select/index.js
@@ -1,2 +1,3 @@
 export { default as MultiSelect } from './src/multi-select';
 export { default as SingleSelect } from './src/single-select';
+export { default as Select } from './src/select';

--- a/src/ui/select/index.js
+++ b/src/ui/select/index.js
@@ -1,3 +1,9 @@
-export { default as MultiSelect } from './src/multi-select';
-export { default as SingleSelect } from './src/single-select';
-export { default as Select } from './src/select';
+import MultiSelect from './src/multi-select';
+import SingleSelect from './src/single-select';
+import Select from './src/select';
+
+export {
+  MultiSelect,
+  Select,
+  SingleSelect,
+};

--- a/src/ui/select/src/multi-select.jsx
+++ b/src/ui/select/src/multi-select.jsx
@@ -14,6 +14,10 @@ import multiValueRenderer from './multi-value-renderer';
 export default class MultiSelect extends PureComponent {
   constructor(props) {
     super(props);
+    console.warn(
+      'Deprecated: MultiSelect will not be available in future versions.'
+      + ' Please use Select with prop `multi`.'
+    );
     this.state = stateFromPropUpdates(MultiSelect.propUpdates, {}, props, {});
   }
 

--- a/src/ui/select/src/multi-select.jsx
+++ b/src/ui/select/src/multi-select.jsx
@@ -15,8 +15,8 @@ export default class MultiSelect extends PureComponent {
   constructor(props) {
     super(props);
     console.warn(
-      'Deprecated: MultiSelect will not be available in future versions.'
-      + ' Please use Select with prop `multi`.'
+      `Deprecated: MultiSelect will not be available in future versions. 
+      Please use Select with prop "multi".`
     );
     this.state = stateFromPropUpdates(MultiSelect.propUpdates, {}, props, {});
   }

--- a/src/ui/select/src/select.jsx
+++ b/src/ui/select/src/select.jsx
@@ -21,8 +21,6 @@ export default class Select extends PureComponent {
     this.setState(
       stateFromPropUpdates(Select.propUpdates, this.props, nextProps, {})
     );
-    this.renderSingleSelect = this.renderSingleSelect.bind(this);
-    this.renderMultiSelect = this.renderMultiSelect.bind(this);
   }
 
   renderSingleSelect() {
@@ -33,25 +31,17 @@ export default class Select extends PureComponent {
       wrapperStyle,
     } = this.state;
 
-    const resetValue = null;
-
-    let placeholder;
-
-    if (!this.props.placeholder) {
-      placeholder = { placeholder: 'Select...' };
-    }
-
     return (
       <BaseSelect
         {...this.props}
-        {...placeholder}
         autofocus
         autosize={false}
         className={classNames(style.select, this.props.className)}
         menuContainerStyle={menuContainerStyle}
         menuRenderer={menuRenderer}
         menuStyle={menuStyle}
-        resetValue={resetValue}
+        placeholder={this.props.placeholder || 'Select...'}
+        resetValue={this.props.resetValue || null}
         searchable
         wrapperStyle={wrapperStyle}
       />
@@ -60,35 +50,25 @@ export default class Select extends PureComponent {
 
   renderMultiSelect() {
     const {
-      resetValue,
-    } = this.props;
-
-    const {
       menuContainerStyle,
       menuRenderer,
       menuStyle,
       wrapperStyle,
     } = this.state;
 
-    let placeholder;
-
-    if (!this.props.placeholder) {
-      placeholder = { placeholder: 'Add/Remove' };
-    }
-
     return (
       <BaseSelect
         {...this.props}
-        {...placeholder}
         autofocus
         autosize={false}
         className={classNames(style.select, this.props.className)}
         clearable
-        menuRenderer={menuRenderer}
-        multi
         menuContainerStyle={menuContainerStyle}
+        menuRenderer={menuRenderer}
         menuStyle={menuStyle}
-        resetValue={resetValue}
+        multi
+        placeholder={this.props.placeholder || 'Add/Remove...'}
+        resetValue={this.props.resetValue || []}
         searchable
         valueComponent={Value}
         valueRenderer={multiValueRenderer}
@@ -98,7 +78,9 @@ export default class Select extends PureComponent {
   }
 
   render() {
-    if (this.props.multiSelect) return this.renderMultiSelect();
+    if (this.props.multi) {
+      return this.renderMultiSelect();
+    }
 
     return this.renderSingleSelect();
   }
@@ -109,7 +91,7 @@ const selectPropTypes = {
   menuUpward: PropTypes.bool,
 
   /* allow multiple selections */
-  multiSelect: PropTypes.bool,
+  multi: PropTypes.bool,
 
   /* width applied to outermost wrapper */
   width: PropTypes.number,
@@ -121,7 +103,6 @@ const selectPropTypes = {
 Select.propTypes = assign({}, baseProps, selectPropTypes);
 
 Select.defaultProps = {
-  resetValue: [],
   widthPad: 60,
 };
 

--- a/src/ui/select/src/select.jsx
+++ b/src/ui/select/src/select.jsx
@@ -1,0 +1,160 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+import { default as BaseSelect, propTypes as baseProps } from 'ihme-react-select';
+import { assign } from 'lodash';
+
+import { stateFromPropUpdates, propsChanged, PureComponent } from '../../../utils';
+import { FLIP_MENU_UPWARDS_INLINE_STYLE, getWidestLabel } from './utils';
+
+import style from './select.css';
+import { menuWrapper } from './menu';
+import Value from './value';
+import multiValueRenderer from './multi-value-renderer';
+
+export default class Select extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = stateFromPropUpdates(Select.propUpdates, {}, props, {});
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(
+      stateFromPropUpdates(Select.propUpdates, this.props, nextProps, {})
+    );
+    this.renderSingleSelect = this.renderSingleSelect.bind(this);
+    this.renderMultiSelect = this.renderMultiSelect.bind(this);
+  }
+
+  renderSingleSelect() {
+    const {
+      menuContainerStyle,
+      menuRenderer,
+      menuStyle,
+      wrapperStyle,
+    } = this.state;
+
+    return (
+      <BaseSelect
+        {...this.props}
+        autofocus
+        autosize={false}
+        className={classNames(style.select, this.props.className)}
+        menuContainerStyle={menuContainerStyle}
+        menuRenderer={menuRenderer}
+        menuStyle={menuStyle}
+        searchable
+        wrapperStyle={wrapperStyle}
+      />
+    );
+  }
+
+  renderMultiSelect() {
+    const {
+      resetValue,
+    } = this.props;
+
+    const {
+      menuContainerStyle,
+      menuRenderer,
+      menuStyle,
+      wrapperStyle,
+    } = this.state;
+
+    return (
+      <BaseSelect
+        {...this.props}
+        autofocus
+        autosize={false}
+        className={classNames(style.select, this.props.className)}
+        clearable
+        menuRenderer={menuRenderer}
+        multi
+        menuContainerStyle={menuContainerStyle}
+        menuStyle={menuStyle}
+        resetValue={resetValue}
+        searchable
+        valueComponent={Value}
+        valueRenderer={multiValueRenderer}
+        wrapperStyle={wrapperStyle}
+      />
+    );
+  }
+
+  render() {
+    if (this.props.multiSelect) return this.renderMultiSelect();
+
+    return this.renderSingleSelect();
+  }
+}
+
+const selectPropTypes = {
+  /* drop down will flip up */
+  menuUpward: PropTypes.bool,
+
+  /* allow multiple selections */
+  multiSelect: PropTypes.bool,
+
+  /* width applied to outermost wrapper */
+  width: PropTypes.number,
+
+  /* width added to widest label (in px) */
+  widthPad: PropTypes.number,
+};
+
+Select.propTypes = assign({}, baseProps, selectPropTypes);
+
+Select.defaultProps = {
+  resetValue: [],
+  widthPad: 60,
+};
+
+Select.propUpdates = {
+  menu(state, _, prevProps, nextProps) {
+    if (!propsChanged(prevProps, nextProps, [
+      'hierarchical',
+      'labelKey',
+      'menuContainerStyle',
+      'menuStyle',
+      'options',
+      'widthPad',
+    ])) {
+      return state;
+    }
+
+    const menuWidth = getWidestLabel(
+        nextProps.options,
+        nextProps.labelKey,
+        nextProps.hierarchical
+      ) + nextProps.widthPad;
+
+    // if menu width changes, also set menuStyle and menuContainerStyle
+    // also create new HoC for menuRenderer
+    return assign(
+      {},
+      state,
+      {
+        menuContainerStyle: assign(
+          {},
+          { width: `${menuWidth}px` },
+          nextProps.menuContainerStyle,
+          nextProps.menuUpward && FLIP_MENU_UPWARDS_INLINE_STYLE
+        ),
+        menuRenderer: menuWrapper(menuWidth),
+        menuStyle: assign(
+          {},
+          { overflow: 'hidden', width: `${menuWidth}px` },
+          nextProps.menuStyle
+        ),
+      }
+    );
+  },
+  wrapperStyle(state, _, prevProps, nextProps) {
+    if (!propsChanged(prevProps, nextProps, ['width', 'wrapperStyle'])) {
+      return state;
+    }
+
+    return assign({}, state, {
+      wrapperStyle: assign({}, { width: `${nextProps.width}px` }, nextProps.wrapperStyle),
+    });
+  }
+};

--- a/src/ui/select/src/select.jsx
+++ b/src/ui/select/src/select.jsx
@@ -33,15 +33,25 @@ export default class Select extends PureComponent {
       wrapperStyle,
     } = this.state;
 
+    const resetValue = null;
+
+    let placeholder;
+
+    if (!this.props.placeholder) {
+      placeholder = { placeholder: 'Select...' };
+    }
+
     return (
       <BaseSelect
         {...this.props}
+        {...placeholder}
         autofocus
         autosize={false}
         className={classNames(style.select, this.props.className)}
         menuContainerStyle={menuContainerStyle}
         menuRenderer={menuRenderer}
         menuStyle={menuStyle}
+        resetValue={resetValue}
         searchable
         wrapperStyle={wrapperStyle}
       />
@@ -60,9 +70,16 @@ export default class Select extends PureComponent {
       wrapperStyle,
     } = this.state;
 
+    let placeholder;
+
+    if (!this.props.placeholder) {
+      placeholder = { placeholder: 'Add/Remove' };
+    }
+
     return (
       <BaseSelect
         {...this.props}
+        {...placeholder}
         autofocus
         autosize={false}
         className={classNames(style.select, this.props.className)}

--- a/src/ui/select/src/single-select.jsx
+++ b/src/ui/select/src/single-select.jsx
@@ -12,6 +12,10 @@ import { menuWrapper } from './menu';
 export default class SingleSelect extends PureComponent {
   constructor(props) {
     super(props);
+    console.warn(
+      'Deprecated: SingleSelect will not be available in future versions.'
+      + ' Please use Select.'
+    );
     this.state = stateFromPropUpdates(SingleSelect.propUpdates, {}, props, {});
   }
 

--- a/src/ui/select/src/single-select.jsx
+++ b/src/ui/select/src/single-select.jsx
@@ -13,8 +13,7 @@ export default class SingleSelect extends PureComponent {
   constructor(props) {
     super(props);
     console.warn(
-      'Deprecated: SingleSelect will not be available in future versions.'
-      + ' Please use Select.'
+      'Deprecated: SingleSelect will not be available in future versions. Please use Select.'
     );
     this.state = stateFromPropUpdates(SingleSelect.propUpdates, {}, props, {});
   }


### PR DESCRIPTION
#89 A new component `Select` that merges a lot of common code from `MultiSelect` and `SingleSelect`. A multi-select component is created via props by the boolean prop `multiselect`. Any suggestions on renaming the prop are welcome. `Select` defaults to a single-select. The demo has been updated to include the new `Select` component.