### PR TITLE
Allow disabling a SelectOption with option.disabled: true.

### DIFF
--- a/src/ui/select/src/select-option.css
+++ b/src/ui/select/src/select-option.css
@@ -19,3 +19,7 @@
   background-color: #27ae60;
   color: #f5f5f5;
 }
+
+.disabled {
+  opacity: 0.5;
+}

--- a/src/ui/select/src/select-option.jsx
+++ b/src/ui/select/src/select-option.jsx
@@ -105,8 +105,8 @@ export default class SelectOption extends React.Component {
       <div
         className={classNames(
           styles.option, {
-            [styles.focused]: !isDisabled && isFocused,
-            [styles.selected]: !isDisabled && isSelected,
+            [styles.focused]: isFocused,
+            [styles.selected]: isSelected,
           }
         )}
         onClick={!isDisabled && this.onClick}

--- a/src/ui/select/src/select-option.jsx
+++ b/src/ui/select/src/select-option.jsx
@@ -107,6 +107,7 @@ export default class SelectOption extends React.Component {
           styles.option, {
             [styles.focused]: isFocused,
             [styles.selected]: isSelected,
+            [styles.disabled]: isDisabled,
           }
         )}
         onClick={!isDisabled && this.onClick}

--- a/src/ui/select/src/select-option.jsx
+++ b/src/ui/select/src/select-option.jsx
@@ -99,17 +99,18 @@ export default class SelectOption extends React.Component {
 
     const isFocused = option === focusedOption;
     const isSelected = valueArray ? valueArray.includes(option) : false;
+    const isDisabled = Boolean(option.disabled);
 
     return (
       <div
         className={classNames(
           styles.option, {
-            [styles.focused]: isFocused,
-            [styles.selected]: isSelected,
+            [styles.focused]: !isDisabled && isFocused,
+            [styles.selected]: !isDisabled && isSelected,
           }
         )}
-        onClick={this.onClick}
-        onMouseOver={this.onMouseOver}
+        onClick={!isDisabled && this.onClick}
+        onMouseOver={!isDisabled && this.onMouseOver}
         style={style}
       >
         {

--- a/src/ui/select/src/test/select-option.test.js
+++ b/src/ui/select/src/test/select-option.test.js
@@ -63,12 +63,6 @@ describe('<SelectOption />', () => {
       disabled: true,
     };
 
-    it('does not apply focused classname even when option has focus', () => {
-      const props = Object.assign({}, baseProps, { focusedOption: option, option });
-      const wrapper = shallow(<SelectOption {...props} />);
-      expect(wrapper).not.to.have.className(styles.focused);
-    });
-
     it('does not call the function passed as selectValue when the option is clicked', () => {
       const selectValue = spy();
       const props = Object.assign({}, baseProps, { selectValue, option });

--- a/src/ui/select/src/test/select-option.test.js
+++ b/src/ui/select/src/test/select-option.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { shallow } from 'enzyme';
+import { spy } from 'sinon';
 
 import SelectOption from '../select-option';
 import styles from '../select-option.css';
@@ -53,6 +54,35 @@ describe('<SelectOption />', () => {
       const props = Object.assign({}, multiBaseProps, { option });
       const wrapper = shallow(<SelectOption {...props} />);
       expect(wrapper.find('Input')).to.not.be.checked();
+    });
+  });
+
+  describe('option.disabled === true', () => {
+    const option = {
+      name: 'Seattle',
+      disabled: true,
+    };
+
+    it('does not apply focused classname even when option has focus', () => {
+      const props = Object.assign({}, baseProps, { focusedOption: option, option });
+      const wrapper = shallow(<SelectOption {...props} />);
+      expect(wrapper).not.to.have.className(styles.focused);
+    });
+
+    it('does not call the function passed as selectValue when the option is clicked', () => {
+      const selectValue = spy();
+      const props = Object.assign({}, baseProps, { selectValue, option });
+      const wrapper = shallow(<SelectOption {...props} />);
+      wrapper.simulate('click');
+      expect(selectValue.notCalled).to.equal(true);
+    });
+
+    it('does not call the function passed as focusOption when the option is moused over', () => {
+      const focusOption = spy();
+      const props = Object.assign({}, baseProps, { focusOption, option });
+      const wrapper = shallow(<SelectOption {...props} />);
+      wrapper.simulate('mouseover');
+      expect(focusOption.notCalled).to.equal(true);
     });
   });
 });

--- a/src/ui/select/src/test/select-option.test.js
+++ b/src/ui/select/src/test/select-option.test.js
@@ -78,5 +78,11 @@ describe('<SelectOption />', () => {
       wrapper.simulate('mouseover');
       expect(focusOption.notCalled).to.equal(true);
     });
+
+    it('applies disabled classname', () => {
+      const props = Object.assign({}, baseProps, { option });
+      const wrapper = shallow(<SelectOption {...props} />);
+      expect(wrapper).to.have.className(styles.disabled);
+    });
   });
 });


### PR DESCRIPTION
- prevents calling props.selectValue on click
- prevents calling props.focusOption on mouseover
- prevents applying 'focused', 'selected' CSS classes
- tests included in commit