### PR TITLE
Feature/choropleth props management

### DIFF
--- a/src/ui/choropleth/demo/app.jsx
+++ b/src/ui/choropleth/demo/app.jsx
@@ -4,7 +4,7 @@ import { render } from 'react-dom';
 import { bindAll, filter, find, flatMap, forEach, includes, values, xor } from 'lodash';
 import { json, scaleLinear } from 'd3';
 
-import { dataGenerator } from '../../../test-utils';
+import { dataGenerator } from '../../../test-utils/data';
 import { colorSteps, linspace } from '../../../utils';
 
 import ResponsiveContainer from '../../responsive-container';
@@ -13,9 +13,9 @@ import Button from '../../button';
 
 // Array is used to maintain layer order.
 const LAYERS = [
-  { name: 'national', object: 'national', type: 'feature', visible: true, },
-  { name: 'subnational', object: 'subnational', type: 'feature', visible: false, },
-  { name: 'boundary', object: 'national', type: 'mesh', visible: false, style: { stroke: 'white', strokeWidth: '5px' }, filterFn: boundaryFilterFn(['101', '102', '130'])},
+  { name: 'national', object: 'national', type: 'feature' },
+  { name: 'subnational', object: 'subnational', type: 'feature' },
+  { name: 'boundary', object: 'national', type: 'mesh', style: { stroke: 'white', strokeWidth: '5px' }, filter: boundaryFilterFn(['101', '102', '130'])},
 ];
 
 function boundaryFilterFn(selections) {
@@ -36,16 +36,14 @@ class App extends React.Component {
   constructor(props) {
     super(props);
 
-    const layers = LAYERS.slice(0);
-
     this.state = {
       selections: [],
-      layers,
+      layers: LAYERS,
       domain: dataRange,
       keyField,
       valueField,
       colorScale,
-      ...this.updateData(layers, props.topology)
+      ...this.updateData(LAYERS, props.topology)
     };
 
     bindAll(this, [
@@ -72,13 +70,10 @@ class App extends React.Component {
     return { data, };
   }
 
-  toggleVisibility(layerName) {
+  toggleVisibility(layer) {
     return () => {
-      const layers = [...this.state.layers];
-
-      forEach(filter(layers, layerName), (layer) => {
-        layer.visible = !layer.visible;
-      });
+      const layerToToggle = filter(LAYERS, layer);
+      const layers = xor(this.state.layers, layerToToggle);
       this.setState({ layers, });
     }
   }
@@ -91,10 +86,10 @@ class App extends React.Component {
     const {
       data,
       keyField,
+      layers,
       valueField,
       colorScale,
       selections,
-      layers
     } = this.state;
 
     return (

--- a/src/ui/choropleth/demo/app.jsx
+++ b/src/ui/choropleth/demo/app.jsx
@@ -15,7 +15,7 @@ import Button from '../../button';
 const LAYERS = [
   { name: 'national', object: 'national', type: 'feature' },
   { name: 'subnational', object: 'subnational', type: 'feature' },
-  { name: 'boundary', object: 'national', type: 'mesh', style: { stroke: 'white', strokeWidth: '5px' }, filter: boundaryFilterFn(['101', '102', '130'])},
+  { name: 'boundary', object: 'national', type: 'mesh', style: { stroke: 'white', strokeWidth: '5px' }, meshFilter: boundaryFilterFn(['101', '102', '130'])},
 ];
 
 function boundaryFilterFn(selections) {

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -454,7 +454,7 @@ Choropleth.propTypes = {
    * layers of topojson to include
    * layer description: {Object}
    *  - `className`: className applied to layer
-   *  - `filterFn`: optional function to filter mesh grid, passed adjacent geometries
+   *  - `filter`: optional function to filter mesh grid, passed adjacent geometries
    *      refer to [https://github.com/mbostock/topojson/wiki/API-Reference#mesh](https://github.com/mbostock/topojson/wiki/API-Reference#mesh)
    *  - `name`: (Required) along with layer.type, will be part of the `key` of the layer; therefore, `${layer.type}-${layer.name}` needs to be unique
    *  - `object`: (Required) name corresponding to key within topojson objects collection
@@ -473,7 +473,7 @@ Choropleth.propTypes = {
      * optional function to filter mesh grid, passed adjacent geometries
      * refer to https://github.com/mbostock/topojson/wiki/API-Reference#mesh
      */
-    filterFn: PropTypes.func,
+    filter: PropTypes.func,
 
     /**
      * along with layer.type, will be part of the `key` of the layer

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -87,6 +87,8 @@ export default class Choropleth extends React.Component {
   componentDidMount() {
     const [x, y] = this.state.translate;
 
+    if (!this._svgSelection) return;
+
     this._svgSelection.call(
       this.zoom
         .on('zoom.ihme-ui-choropleth', this.zoomEvent)
@@ -169,12 +171,14 @@ export default class Choropleth extends React.Component {
         this.clipExtent
       );
 
-      this._svgSelection.call(
-        this.zoom.transform,
-        zoomIdentity
-          .translate(state.translate[0], state.translate[1])
-          .scale(state.scale)
-      );
+      if (this._svgSelection) {
+        this._svgSelection.call(
+          this.zoom.transform,
+          zoomIdentity
+            .translate(state.translate[0], state.translate[1])
+            .scale(state.scale)
+        );
+      }
     }
 
     // if the data has changed, transform it to be consumable by <Layer />

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -116,9 +116,7 @@ export default class Choropleth extends React.Component {
         cache = {};
       }
 
-      const visibleLayers = filter(nextProps.layers, { visible: true });
-
-      const uncachedLayers = filter(visibleLayers, (layer) =>
+      const uncachedLayers = filter(nextProps.layers, layer =>
         layer.type === 'mesh' || !has(cache[layer.type], layer.name)
       );
 
@@ -284,8 +282,6 @@ export default class Choropleth extends React.Component {
 
   renderLayers() {
     return this.props.layers.map((layer) => {
-      if (!layer.visible) return null;
-
       const key = `${layer.type}-${layer.name}`;
 
       switch (layer.type) {
@@ -465,7 +461,6 @@ Choropleth.propTypes = {
    *      func: (feature) => style object
    *  - `type`: (Required) whether the layer should be a feature collection or mesh grid
    *      one of: "feature", "mesh"
-   *  - `visible`: whether or not to render layer
    */
   layers: PropTypes.arrayOf(PropTypes.shape({
     className: CommonPropTypes.className,
@@ -517,13 +512,6 @@ Choropleth.propTypes = {
      * one of: "feature", "mesh"
      */
     type: PropTypes.oneOf(['feature', 'mesh']).isRequired,
-
-    /**
-     * whether or not to render layer
-     * WILL BE DEPRECATED: if you do not want to render the layer,
-     * do not include its description in this array
-     */
-    visible: PropTypes.bool,
   })).isRequired,
 
   /**

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -85,9 +85,9 @@ export default class Choropleth extends React.Component {
   }
 
   componentDidMount() {
-    const [x, y] = this.state.translate;
-
     if (!this._svgSelection) return;
+
+    const [x, y] = this.state.translate;
 
     this._svgSelection.call(
       this.zoom

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -172,10 +172,11 @@ export default class Choropleth extends React.Component {
       );
 
       if (this._svgSelection) {
+        const [x, y] = state.translate;
         this._svgSelection.call(
           this.zoom.transform,
           zoomIdentity
-            .translate(state.translate[0], state.translate[1])
+            .translate(x, y)
             .scale(state.scale)
         );
       }

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -454,7 +454,7 @@ Choropleth.propTypes = {
    * layers of topojson to include
    * layer description: {Object}
    *  - `className`: className applied to layer
-   *  - `filter`: optional function to filter mesh grid, passed adjacent geometries
+   *  - `meshFilter`: optional function to filter mesh grid, passed adjacent geometries
    *      refer to [https://github.com/mbostock/topojson/wiki/API-Reference#mesh](https://github.com/mbostock/topojson/wiki/API-Reference#mesh)
    *  - `name`: (Required) along with layer.type, will be part of the `key` of the layer; therefore, `${layer.type}-${layer.name}` needs to be unique
    *  - `object`: (Required) name corresponding to key within topojson objects collection
@@ -473,7 +473,7 @@ Choropleth.propTypes = {
      * optional function to filter mesh grid, passed adjacent geometries
      * refer to https://github.com/mbostock/topojson/wiki/API-Reference#mesh
      */
-    filter: PropTypes.func,
+    meshFilter: PropTypes.func,
 
     /**
      * along with layer.type, will be part of the `key` of the layer

--- a/src/ui/choropleth/test/choropleth.test.js
+++ b/src/ui/choropleth/test/choropleth.test.js
@@ -16,7 +16,7 @@ describe('<Choropleth />', () => {
   const valueField = 'mean';
   const layers = [
     { name: 'country', object: 'country', type: 'feature' },
-    { name: 'states', object: 'states', type: 'mesh', filter: (a, b) => a !== b },
+    { name: 'states', object: 'states', type: 'mesh', meshFilter: (a, b) => a !== b },
   ];
   const geo = getTopoJSON();
   const locIds = [102, ...getLocationIds(geo.objects.states.geometries)];

--- a/src/ui/compositions/map/src/map.jsx
+++ b/src/ui/compositions/map/src/map.jsx
@@ -241,7 +241,6 @@ export default class Map extends React.Component {
         style: styleReset,
         selectedStyle: styleReset,
         type: 'feature',
-        visible: true,
       },
       {
         name: `${name}-disputed-borders`,
@@ -249,7 +248,6 @@ export default class Map extends React.Component {
         style: { stroke: 'black', strokeWidth: '1px', strokeDasharray: '5, 5' },
         type: 'mesh',
         filterFn: this.disputedBordersMeshFilter,
-        visible: true,
       },
       {
         name: `${name}-non-disputed-borders`,
@@ -257,7 +255,6 @@ export default class Map extends React.Component {
         style: { stroke: 'black', strokeWidth: '1px' },
         type: 'mesh',
         filterFn: this.nonDisputedBordersMeshFilter,
-        visible: true,
       },
       {
         name: `${name}-selected-non-disputed-borders`,
@@ -265,7 +262,6 @@ export default class Map extends React.Component {
         style: { stroke: 'black', strokeWidth: '2px' },
         type: 'mesh',
         filterFn: this.selectedBordersMeshFilter,
-        visible: true,
       },
     ];
   }

--- a/src/ui/compositions/map/src/map.jsx
+++ b/src/ui/compositions/map/src/map.jsx
@@ -247,21 +247,21 @@ export default class Map extends React.Component {
         object: name,
         style: { stroke: 'black', strokeWidth: '1px', strokeDasharray: '5, 5' },
         type: 'mesh',
-        filterFn: this.disputedBordersMeshFilter,
+        filter: this.disputedBordersMeshFilter,
       },
       {
         name: `${name}-non-disputed-borders`,
         object: name,
         style: { stroke: 'black', strokeWidth: '1px' },
         type: 'mesh',
-        filterFn: this.nonDisputedBordersMeshFilter,
+        filter: this.nonDisputedBordersMeshFilter,
       },
       {
         name: `${name}-selected-non-disputed-borders`,
         object: name,
         style: { stroke: 'black', strokeWidth: '2px' },
         type: 'mesh',
-        filterFn: this.selectedBordersMeshFilter,
+        filter: this.selectedBordersMeshFilter,
       },
     ];
   }

--- a/src/ui/compositions/map/src/map.jsx
+++ b/src/ui/compositions/map/src/map.jsx
@@ -247,21 +247,21 @@ export default class Map extends React.Component {
         object: name,
         style: { stroke: 'black', strokeWidth: '1px', strokeDasharray: '5, 5' },
         type: 'mesh',
-        filter: this.disputedBordersMeshFilter,
+        meshFilter: this.disputedBordersMeshFilter,
       },
       {
         name: `${name}-non-disputed-borders`,
         object: name,
         style: { stroke: 'black', strokeWidth: '1px' },
         type: 'mesh',
-        filter: this.nonDisputedBordersMeshFilter,
+        meshFilter: this.nonDisputedBordersMeshFilter,
       },
       {
         name: `${name}-selected-non-disputed-borders`,
         object: name,
         style: { stroke: 'black', strokeWidth: '2px' },
         type: 'mesh',
-        filter: this.selectedBordersMeshFilter,
+        meshFilter: this.selectedBordersMeshFilter,
       },
     ];
   }

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -8,7 +8,7 @@ const defaultMeshFilter = () => { return true; };
  * extract topojson layers as geoJSON
  * @param {Object} topology -> valid topojson
  * @param {Array} layers -> layers to include
- *   each layer is an object with keys 'name', 'type', and, optionally, 'filterFn'
+ *   each layer is an object with keys 'name', 'type', and, optionally, 'filter'
  *   'name' must map to a key in topology.objects
  *   'type' is one of 'feature' or 'mesh', defaults to 'feature'
  * @return {Object} -> { mesh: {...}, feature: {...}  }
@@ -20,14 +20,14 @@ export function extractGeoJSON(topology, layers) {
 
     switch (layer.type) {
       case 'mesh':
-        // if filterFn is undefined, the mesh grid will be unfiltered
+        // if filter is undefined, the mesh grid will be unfiltered
         return {
           ...acc,
           mesh: {
             ...acc.mesh,
             [layer.name]: topojson.mesh(topology,
                                         topology.objects[layer.object],
-                                        layer.filterFn || defaultMeshFilter),
+                                        layer.filter || defaultMeshFilter),
           },
         };
       case 'feature': // FALL THROUGH

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -8,7 +8,7 @@ const defaultMeshFilter = () => { return true; };
  * extract topojson layers as geoJSON
  * @param {Object} topology -> valid topojson
  * @param {Array} layers -> layers to include
- *   each layer is an object with keys 'name', 'type', and, optionally, 'filter'
+ *   each layer is an object with keys 'name', 'type', and, optionally, 'meshFilter'
  *   'name' must map to a key in topology.objects
  *   'type' is one of 'feature' or 'mesh', defaults to 'feature'
  * @return {Object} -> { mesh: {...}, feature: {...}  }
@@ -27,7 +27,7 @@ export function extractGeoJSON(topology, layers) {
             ...acc.mesh,
             [layer.name]: topojson.mesh(topology,
                                         topology.objects[layer.object],
-                                        layer.filter || defaultMeshFilter),
+                                        layer.meshFilter || defaultMeshFilter),
           },
         };
       case 'feature': // FALL THROUGH


### PR DESCRIPTION
Props management for `<Choropleth />`:
- removes layer.visible and associated logic
- renames layer.filterFn to layer.filter to remove unnecessary verbosity 

Closes #78.