### PR TITLE
Select option labels should be able to be falsey

### DIFF
--- a/src/ui/select/src/select-option-label.jsx
+++ b/src/ui/select/src/select-option-label.jsx
@@ -1,4 +1,6 @@
 import React, { PropTypes } from 'react';
+import { default as getValue } from 'lodash/get';
+
 
 /**
  * Flat option label
@@ -12,7 +14,7 @@ const flatOptionPropTypes = {
 };
 
 export function FlatOptionLabel(props) {
-  return <span>{props.option[props.labelKey] || ''}</span>;
+  return <span>{`${getValue(props.option, [props.labelKey], '')}`}</span>;
 }
 
 FlatOptionLabel.propTypes = flatOptionPropTypes;
@@ -40,7 +42,7 @@ export function HierarchicalOptionLabel(props) {
         fontWeight: props.option.bold ? 'bold' : 'normal',
       }}
     >
-      {props.option[props.labelKey] || ''}
+      {`${getValue(props.option, [props.labelKey], '')}`}
     </span>
   );
 }

--- a/src/ui/select/src/test/select-option-label.test.js
+++ b/src/ui/select/src/test/select-option-label.test.js
@@ -26,10 +26,24 @@ describe('<SelectOptionLabel', () => {
         option: {
           name: 'Seattle',
         },
+        labelKey: 'other'
       };
       const wrapper = shallow(<FlatOptionLabel {...props} />);
 
       expect(wrapper).to.have.text('');
+    });
+
+    it('returns proper label if option[labelKey] is falsey but not undefined', () => {
+      const spec = [
+        { props: { option: { name: 0 }, labelKey: 'name' }, expectation: '0' },
+        { props: { option: { name: false }, labelKey: 'name' }, expectation: 'false' },
+        { props: { option: { name: null }, labelKey: 'name' }, expectation: 'null' },
+        { props: { option: { name: '' }, labelKey: 'name' }, expectation: '' },
+      ];
+      spec.forEach(test => {
+        const wrapper = shallow(<FlatOptionLabel {...test.props} />);
+        expect(wrapper).to.have.text(test.expectation);
+      });
     });
   });
 

--- a/src/ui/select/src/test/select-option-label.test.js
+++ b/src/ui/select/src/test/select-option-label.test.js
@@ -22,15 +22,14 @@ describe('<SelectOptionLabel', () => {
     });
 
     it('returns an empty string if option[labelKey] is undefined', () => {
-      const props = {
-        option: {
-          name: 'Seattle',
-        },
-        labelKey: 'other'
-      };
-      const wrapper = shallow(<FlatOptionLabel {...props} />);
-
-      expect(wrapper).to.have.text('');
+      const spec = [
+        { option: { name: 'Seattle' }, labelKey: 'other' },
+        { option: { name: undefined }, labelKey: 'name' },
+      ];
+      spec.forEach(props => {
+        const wrapper = shallow(<FlatOptionLabel {...props} />);
+        expect(wrapper).to.have.text('');
+      });
     });
 
     it('returns proper label if option[labelKey] is falsey but not undefined', () => {
@@ -38,6 +37,7 @@ describe('<SelectOptionLabel', () => {
         { props: { option: { name: 0 }, labelKey: 'name' }, expectation: '0' },
         { props: { option: { name: false }, labelKey: 'name' }, expectation: 'false' },
         { props: { option: { name: null }, labelKey: 'name' }, expectation: 'null' },
+        { props: { option: { name: NaN }, labelKey: 'name' }, expectation: 'NaN' },
         { props: { option: { name: '' }, labelKey: 'name' }, expectation: '' },
       ];
       spec.forEach(test => {
@@ -71,6 +71,31 @@ describe('<SelectOptionLabel', () => {
       spec.forEach((test) => {
         const wrapper = shallow(<HierarchicalOptionLabel {...test.props} />);
         expect(wrapper).to.have.style('font-weight', test.expectation);
+      });
+    });
+
+    it('returns an empty string if option[labelKey] is undefined', () => {
+      const spec = [
+        { option: { name: 'Seattle' }, labelKey: 'other' },
+        { option: { name: undefined }, labelKey: 'name' },
+      ];
+      spec.forEach(props => {
+        const wrapper = shallow(<HierarchicalOptionLabel {...props} />);
+        expect(wrapper).to.have.text('');
+      });
+    });
+
+    it('returns proper label if option[labelKey] is falsey but not undefined', () => {
+      const spec = [
+        { props: { option: { name: 0 }, labelKey: 'name' }, expectation: '0' },
+        { props: { option: { name: false }, labelKey: 'name' }, expectation: 'false' },
+        { props: { option: { name: null }, labelKey: 'name' }, expectation: 'null' },
+        { props: { option: { name: NaN }, labelKey: 'name' }, expectation: 'NaN' },
+        { props: { option: { name: '' }, labelKey: 'name' }, expectation: '' },
+      ];
+      spec.forEach(test => {
+        const wrapper = shallow(<HierarchicalOptionLabel {...test.props} />);
+        expect(wrapper).to.have.text(test.expectation);
       });
     });
   });


### PR DESCRIPTION
Currently, a `<Select />` option label will default to empty string if `option[labelKey]` is falsey. This makes it impossible to render a label with a '0', or 'false'. This fix changes behavior such that empty string will only be returned if `option[labelKey]` is undefined.