### PR TITLE
Check explicitly for undefined in Slider#updateValueFromEvent

### DIFF
--- a/src/ui/slider/src/slider.jsx
+++ b/src/ui/slider/src/slider.jsx
@@ -185,7 +185,7 @@ export default class Slider extends PureComponent {
   }
 
   updateValueFromEvent(event, index, key, callback) {
-    if (index !== this.state.indexes[key] && this.state.range[index]) {
+    if (index !== this.state.indexes[key] && this.state.range[index] !== undefined) {
       const indexes = { ...this.state.indexes, [key]: index };
       const values = getValuesForIndexes(indexes, this.state.range);
 


### PR DESCRIPTION

Truthiness test causes a bug when a range value is 0 (or potentially some other falsy value).