### PR TITLE
Ih 47 button class name style

### DIFF
--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -22,6 +22,7 @@ export default class Button extends PureComponent {
     super(props);
 
     this.combineStyles = memoizeByLastCall(combineStyles);
+    this.iconCombineStyles = memoizeByLastCall(combineStyles);
     this.state = stateFromPropUpdates(Button.propUpdates, {}, props, {});
   }
 
@@ -45,6 +46,7 @@ export default class Button extends PureComponent {
       theme,
     } = this.props;
     const {
+      iconStyleList,
       styleList,
     } = this.state;
 
@@ -68,6 +70,7 @@ export default class Button extends PureComponent {
             className={classNames(styles.icon, iconClassName)}
             alt=""
             src={icon}
+            style={this.iconCombineStyles(iconStyleList)}
           />
         }
         {!showSpinner && (children || text)}
@@ -106,6 +109,11 @@ Button.propTypes = {
    * className applied to icon
    */
   iconClassName: CommonPropTypes.className,
+
+  /**
+   * inline styles to apply to icon
+   */
+  iconStyle: CommonPropTypes.style,
 
   /**
    * id value for button
@@ -166,6 +174,18 @@ Button.propUpdates = {
 
     return assign({}, accum, {
       styleList,
+    });
+  },
+  // update iconStyleList if icon or iconStyle have changed
+  iconStyleList: (accum, propName, prevProps, nextProps) => {
+    const propsToCheck = [
+      'icon',
+      'iconStyle',
+    ];
+    if (!propsChanged(prevProps, nextProps, propsToCheck)) return accum;
+
+    return assign({}, accum, {
+      iconStyleList: [nextProps.iconStyle],
     });
   },
 };

--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -36,6 +36,7 @@ export default class Button extends PureComponent {
       disabled,
       disabledClassName,
       icon,
+      iconClassName,
       id,
       name,
       onClick,
@@ -60,7 +61,15 @@ export default class Button extends PureComponent {
         type="button"
       >
         {showSpinner && <LoadingIndicator inline />}
-        {!showSpinner && icon && <img className={styles.icon} alt="" src={icon} />}
+        {
+          !showSpinner
+          && icon
+          && <img
+            className={classNames(styles.icon, iconClassName)}
+            alt=""
+            src={icon}
+          />
+        }
         {!showSpinner && (children || text)}
       </button>
     );
@@ -92,6 +101,11 @@ Button.propTypes = {
    * path to image to render within button tag
    */
   icon: PropTypes.string,
+
+  /**
+   * className applied to icon
+   */
+  iconClassName: CommonPropTypes.className,
 
   /**
    * id value for button


### PR DESCRIPTION
The objective of this PR is to close #76 -> Button: standardize className and style props.
I have tried to follow the newest conventions using combineStyles and combining the appropriate styles in propUpdates.  Disabled - seems to be the only auxiliary style to incorporate at this time (comparable to focus and the like that other components have).  

One point of style convention: I put the props to check in propUpdates into a `propsToCheck` variable.  This was something Aaron had pointed out as hard to read in my work on the Aster chart.