### PR TITLE
Add link on travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # [IHME-UI](https://github.com/ihmeuw/ihme-ui)
 
-ihme-ui is a collection of JavaScript utilities and React-based user interface elements and visualization components developed by the [Institute of Health Metrics and Evaluation](http://healthdata.org). 
+ihme-ui is a collection of JavaScript utilities and React-based user interface elements and visualization components developed by the [Institute of Health Metrics and Evaluation](http://healthdata.org).
 This collection is used in IHME's [visualizations of global health metrics](http://www.healthdata.org/results/data-visualizations).
 
 ###### WORK IN PROGRESS: Not stable until v1.0.0
@@ -18,8 +18,8 @@ npm install -S ihme-ui
 ## Getting started
 
 In it's most simple form, this library can be included in a `<script />` tag and accessed off of `window` as `ihmeUI`.
-If you've installed the library from the [npm registry](https://www.npmjs.com/package/ihme-ui), you can pull the library out of your `node_modules` folder. 
-If not, grab it off of the unoffical NPM CDN, [unpkg](https://unpkg.com/#/). 
+If you've installed the library from the [npm registry](https://www.npmjs.com/package/ihme-ui), you can pull the library out of your `node_modules` folder.
+If not, grab it off of the unoffical NPM CDN, [unpkg](https://unpkg.com/#/).
 ```html
 
 <!DOCTYPE html>
@@ -43,14 +43,14 @@ If not, grab it off of the unoffical NPM CDN, [unpkg](https://unpkg.com/#/).
       domain: ihmeUI.linspace([3, 10], 200),
       ...
     });
-    
+
     ReactDOM.render(chart, document.getElementById('app'));
   </script>
 </body>
 </html>
 ```
 
-In most cases, however, you'll be importing ihme-ui into your project, and bundling it with a module bundler like [Webpack](https://webpack.github.io/) or [Rollup](http://rollupjs.org/). 
+In most cases, however, you'll be importing ihme-ui into your project, and bundling it with a module bundler like [Webpack](https://webpack.github.io/) or [Rollup](http://rollupjs.org/).
 In support of this, `ihme-ui` exposes both a CommonJS (i.e., `var ihmeUI = require('ihme-ui')`) and an ES module (i.e., `import ihmeUI from 'ihme-ui'`) target.
 ```javascript
 // index.js

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![travis badge](https://travis-ci.org/ihmeuw/ihme-ui.svg) [![codecov.io](https://codecov.io/github/ihmeuw/ihme-ui/coverage.svg?branch=master)](https://codecov.io/github/ihmeuw/ihme-ui?branch=master)
+[![Build Status](https://travis-ci.org/ihmeuw/ihme-ui.svg?branch=master)](https://travis-ci.org/ihmeuw/ihme-ui) [![codecov.io](https://codecov.io/github/ihmeuw/ihme-ui/coverage.svg?branch=master)](https://codecov.io/github/ihmeuw/ihme-ui?branch=master)
 
 # [IHME-UI](https://github.com/ihmeuw/ihme-ui)
 


### PR DESCRIPTION
Adding a link to our Travis badge, which displays at the top of the README (and thus on the project page), provides an easy way to navigate to the corresponding Travis project. This code was copied directly from Travis CI's status image creator.