### PR TITLE
Tooltip fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ihme-ui",
   "description": "Visualization tools from the Institute for Health Metrics and Evaluation",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "license": "MIT",
   "browser": "dist/ihme-ui.min.js",
   "main": "lib/index.js",

--- a/src/ui/tooltip/src/tooltip.jsx
+++ b/src/ui/tooltip/src/tooltip.jsx
@@ -251,7 +251,7 @@ Tooltip.propUpdates = {
       paddingY: nextProps.paddingY,
       width,
     });
-    return assign({}, accum, { transform: `translate(${x}px, ${y}px)` });
+    return assign({}, accum, { top: `${y}px`, left: `${x}px` });
     /* eslint-enable no-underscore-dangle */
   },
   display: (accum, _, prevProps, nextProps) => {


### PR DESCRIPTION
This PR is a fix to a bug in firefox running on windows. It gets rid of render artifacts when the tooltip is set to `visibility:hidden`. According to [this article from 2012](https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/) translate has better performance. But maybe times have changed.