### PR TITLE
React move line

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,4 @@ module.exports = {
     "browser": true,
     "mocha": true
   },
-  "ecmaFeatures": {
-    "experimentalObjectRestSpread": true
-  }
 };

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { schemeCategory10, scaleOrdinal } from 'd3';
+import {
+  scaleLinear,
+  scaleOrdinal,
+  schemeCategory10,
+} from 'd3';
 
 import { bindAll, maxBy, minBy, map, slice, uniqBy, without, xor } from 'lodash';
 
 import { dataGenerator } from '../../../utils';
 import AxisChart from '../../axis-chart';
 import { XAxis, YAxis } from '../../axis';
-import { MultiScatter, Scatter } from '../';
+import { Line, MultiScatter, Scatter } from '../';
 
 const keyField = 'year_id';
 const valueField = 'population';
@@ -56,7 +60,12 @@ class App extends React.Component {
       'onMouseLeave',
       'onMouseMove',
       'onMouseOver',
+      'setNextLocation',
     ]);
+  }
+
+  setNextLocation() {
+    this.setState({ country: (this.state.country + 1) % locationData.length });
   }
 
   onClick(event, datum) {
@@ -84,9 +93,41 @@ class App extends React.Component {
     });
   };
 
+  renderLineDemo() {
+    return (
+      <section>
+        <h3>Line</h3>
+        <h3>{locationData[this.state.country].location}</h3>
+        <button onClick={this.setNextLocation}>
+          press to look at next country
+        </button>
+        <AxisChart
+          height={300}
+          width={500}
+          xDomain={keyFieldDomain}
+          xScaleType="point"
+          yDomain={valueFieldDomain}
+          yScaleType="linear"
+        >
+          <XAxis />
+          <YAxis />
+          <Line
+            animate
+            data={data.filter(
+              datum => datum.location === locationData[this.state.country].location,
+            )}
+            dataAccessors={{ x: 'year_id', y: 'population' }}
+            scales={{ x: scaleLinear(), y: scaleLinear() }}
+          />
+        </AxisChart>
+      </section>
+    );
+  }
+
   render() {
     return (
       <div style={{ display: 'flex', flexDirection: 'column' }}>
+        {this.renderLineDemo()}
         <section>
           <h3>Multiple datasets</h3>
 {/* <pre><code>
@@ -207,11 +248,7 @@ class App extends React.Component {
  </AxisChart>
  </code></pre> */}
           <h3>{locationData[this.state.country].location}</h3>
-          <button
-            onClick={() => {
-              this.setState({ country: (this.state.country + 1) % locationData.length });
-            }}
-          >
+          <button onClick={this.setNextLocation}>
             press to look at next country
           </button>
             <AxisChart
@@ -228,7 +265,7 @@ class App extends React.Component {
                 animate
                 fill="steelblue"
                 data={data.filter(
-                  (datum) => datum.location === locationData[this.state.country].location,
+                  datum => datum.location === locationData[this.state.country].location,
                 )}
                 dataAccessors={{
                   fill: keyField,

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -13,7 +13,12 @@ import { bindAll, maxBy, minBy, map, slice, uniqBy, without, xor } from 'lodash'
 import { dataGenerator } from '../../../utils';
 import AxisChart from '../../axis-chart';
 import { XAxis, YAxis } from '../../axis';
-import { Line, MultiScatter, Scatter } from '../';
+import {
+  Line,
+  MultiLine,
+  MultiScatter,
+  Scatter,
+} from '../';
 
 const keyField = 'year_id';
 const valueField = 'population';
@@ -100,6 +105,84 @@ class App extends React.Component {
     });
   };
 
+  renderMultiLineDemo() {
+    const lineDataSet = locationData.reduce(
+      (accum, line, index) => {
+        switch(index) {
+          case this.state.country:
+            accum.push({ ...line, key: 0 });
+            break;
+          case (this.state.country + 1) % locationData.length:
+            accum.push({ ...line, key: 1 });
+            break;
+          case (this.state.country + 2) % locationData.length:
+            accum.push({ ...line, key: 2 });
+            break;
+        }
+        return accum;
+      },
+      [],
+    ).sort((line_a, line_b) => line_a.key - line_b.key);
+
+    return (
+      <section>
+        <h3>Multi Line</h3>
+        <p>
+          {lineDataSet.map(({ location, key }) =>
+            <span style={{
+              backgroundColor: colorScale(location),
+              marginRight: 5,
+              color: 'white',
+              padding: 10,
+            }}>line {key + 1}</span>
+          )}
+        </p>
+        <button onClick={this.setNextLocation}>
+          press to look at next line set
+        </button>
+        <AxisChart
+          height={300}
+          width={500}
+          xDomain={keyFieldDomain}
+          xScaleType="point"
+          yDomain={valueFieldDomain}
+          yScaleType="linear"
+        >
+          <XAxis />
+          <YAxis />
+          <MultiLine
+            animate={{
+              timing: { duration: 666 },
+              stroke: { start() { console.log('started'); return {}; }},
+            }}
+            colorScale={colorScale}
+            data={lineDataSet}
+            dataAccessors={{
+              x: 'year_id',
+              y: 'population',
+            }}
+            fieldAccessors={{
+              key: 'key',
+              color: 'location',
+              data: 'values',
+            }}
+            scales={{ x: scaleLinear(), y: scaleLinear() }}
+            lineStyle={(values) => {
+              const [{ location }] = values;
+              if (location === locationData[this.state.country].location) {
+                return {
+                  strokeWidth: this.state.country + 1,
+                  strokeDasharray: 5,
+                };
+              }
+              return {};
+            }}
+          />
+        </AxisChart>
+      </section>
+    )
+  }
+
   renderLineDemo() {
     const style = {
       shapeRendering: 'geometricPrecision',
@@ -157,6 +240,7 @@ class App extends React.Component {
     return (
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         {this.renderLineDemo()}
+        {this.renderMultiLineDemo()}
         <section>
           <h3>Multiple datasets</h3>
 {/* <pre><code>

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -125,7 +125,24 @@ class App extends React.Component {
           <XAxis />
           <YAxis />
           <Line
-            animate
+            animate={{
+              d: { timing: { duration: 3300 }},
+              stroke: () => ({
+                timing: { delay: 1000, duration: 3000 },
+                events: {
+                  interrupt() {
+                    console.log('The `stroke` animation has been interrupted!');
+                  },
+                },
+              }),
+              strokeWidth: {
+                timing: { duration: 2500 },
+                events: {
+                  end: () => { console.log('The `strokeWidth` animation has ended!'); },
+                },
+              },
+              timing: { duration: 333 }
+            }}
             data={this.getCurrentLocationData()}
             dataAccessors={{ x: 'year_id', y: 'population' }}
             scales={{ x: scaleLinear(), y: scaleLinear() }}

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -14,6 +14,7 @@ import { dataGenerator } from '../../../utils';
 import AxisChart from '../../axis-chart';
 import { XAxis, YAxis } from '../../axis';
 import {
+  Area,
   Line,
   MultiLine,
   MultiScatter,
@@ -44,6 +45,10 @@ const locationData = [
 ];
 
 const valueFieldDomain = [minBy(data, valueField)[valueField], maxBy(data, valueField)[valueField]];
+const valueUncertaintyDomain = [
+  minBy(data, 'population_lb')['population_lb'],
+  maxBy(data, 'population_ub')['population_ub']
+];
 
 const keyFieldDomain = map(uniqBy(data, keyField), (obj) => { return (obj[keyField]); });
 
@@ -202,14 +207,23 @@ class App extends React.Component {
           width={500}
           xDomain={keyFieldDomain}
           xScaleType="point"
-          yDomain={valueFieldDomain}
+          yDomain={valueUncertaintyDomain}
           yScaleType="linear"
         >
           <XAxis />
           <YAxis />
+          <Area
+            animate
+            data={this.getCurrentLocationData()}
+            dataAccessors={{ x: 'year_id', y0: 'population_lb', y1: 'population_ub' }}
+            scales={{ x: scaleLinear(), y: scaleLinear() }}
+            style={{
+              fill: colorScale(this.state.country + 1),
+              opacity: 0.4,
+            }}
+          />
           <Line
             animate={{
-              d: { timing: { duration: 3300 }},
               stroke: () => ({
                 timing: { delay: 1000, duration: 3000 },
                 events: {
@@ -224,7 +238,6 @@ class App extends React.Component {
                   end: () => { console.log('The `strokeWidth` animation has ended!'); },
                 },
               },
-              timing: { duration: 333 }
             }}
             data={this.getCurrentLocationData()}
             dataAccessors={{ x: 'year_id', y: 'population' }}

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import {
+  range,
   scaleLinear,
   scaleOrdinal,
   schemeCategory10,
@@ -100,6 +101,12 @@ class App extends React.Component {
   };
 
   renderLineDemo() {
+    const style = {
+      shapeRendering: 'geometricPrecision',
+      stroke: colorScale(this.state.country),
+      strokeWidth: this.state.country + 1,
+    };
+
     return (
       <section>
         <h3>Line</h3>
@@ -122,6 +129,7 @@ class App extends React.Component {
             data={this.getCurrentLocationData()}
             dataAccessors={{ x: 'year_id', y: 'population' }}
             scales={{ x: scaleLinear(), y: scaleLinear() }}
+            style={style}
           />
         </AxisChart>
       </section>

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -132,6 +132,47 @@ class App extends React.Component {
     return (
       <section>
         <h3>Multi Line</h3>
+{/* <pre><code>
+ <AxisChart
+   height={300}
+   width={500}
+   xDomain={keyFieldDomain}
+   xScaleType="point"
+   yDomain={valueFieldDomain}
+   yScaleType="linear"
+ >
+   <XAxis />
+   <YAxis />
+   <MultiLine
+     animate={{
+       timing: { duration: 666 },
+       stroke: { start() { console.log('started'); return {}; }},
+     }}
+     colorScale={colorScale}
+     data={lineDataSet}
+     dataAccessors={{
+       x: 'year_id',
+       y: 'population',
+     }}
+     fieldAccessors={{
+       key: 'key',
+       color: 'location',
+       data: 'values',
+     }}
+     scales={{ x: scaleLinear(), y: scaleLinear() }}
+     lineStyle={(values) => {
+       const [{ location }] = values;
+       if (location === locationData[this.state.country].location) {
+         return {
+           strokeWidth: this.state.country + 1,
+           strokeDasharray: 5,
+         };
+       }
+       return {};
+     }}
+   />
+ </AxisChart>
+</code></pre> */}
         <p>
           {lineDataSet.map(({ location, key }) =>
             <span style={{
@@ -198,6 +239,52 @@ class App extends React.Component {
     return (
       <section>
         <h3>Line</h3>
+{/* <pre><code>
+ <AxisChart
+   height={300}
+   width={500}
+   xDomain={keyFieldDomain}
+   xScaleType="point"
+   yDomain={valueUncertaintyDomain}
+   yScaleType="linear"
+ >
+   <XAxis />
+   <YAxis />
+   <Area
+     animate
+     data={currentLocationData}
+     dataAccessors={{
+       x: 'year_id',
+       y0: 'population_lb',
+       y1: 'population_ub',
+     }}
+     scales={{ x: scaleLinear(), y: scaleLinear() }}
+     style={{ fill: colorScale(currentLocationId), opacity: 0.4 }}
+   />
+   <Line
+     animate={{
+       stroke: () => ({
+         timing: { delay: 1000, duration: 3000 },
+         events: {
+           interrupt() {
+             console.log('The `stroke` animation has been interrupted!');
+           },
+         },
+       }),
+       strokeWidth: {
+         timing: { duration: 2500 },
+         events: {
+           end: () => { console.log('The `strokeWidth` animation has ended!'); },
+         },
+       },
+     }}
+     data={this.getCurrentLocationData()}
+     dataAccessors={{ x: 'year_id', y: 'population' }}
+     scales={{ x: scaleLinear(), y: scaleLinear() }}
+     style={style}
+   />
+ </AxisChart>
+</code></pre> */}
         <h3>{locationData[this.state.country].location}</h3>
         <button onClick={this.setNextLocation}>
           press to look at next country
@@ -215,8 +302,15 @@ class App extends React.Component {
           <Area
             animate
             data={this.getCurrentLocationData()}
-            dataAccessors={{ x: 'year_id', y0: 'population_lb', y1: 'population_ub' }}
-            scales={{ x: scaleLinear(), y: scaleLinear() }}
+            dataAccessors={{
+              x: 'year_id',
+              y0: 'population_lb',
+              y1: 'population_ub',
+            }}
+            scales={{
+              x: scaleLinear(),
+              y: scaleLinear(),
+            }}
             style={{
               fill: colorScale(this.state.country + 1),
               opacity: 0.4,

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -111,23 +111,18 @@ class App extends React.Component {
   };
 
   renderMultiLineDemo() {
-    const lineDataSet = locationData.reduce(
-      (accum, line, index) => {
-        switch(index) {
-          case this.state.country:
-            accum.push({ ...line, key: 0 });
-            break;
-          case (this.state.country + 1) % locationData.length:
-            accum.push({ ...line, key: 1 });
-            break;
-          case (this.state.country + 2) % locationData.length:
-            accum.push({ ...line, key: 2 });
-            break;
-        }
-        return accum;
-      },
-      [],
-    ).sort((line_a, line_b) => line_a.key - line_b.key);
+    const lineDataSet = locationData.map((line, index) => {
+      switch(index) {
+        case this.state.country:
+          return { ...line, key: 0 };
+        case (this.state.country + 1) % locationData.length:
+          return { ...line, key: 1 };
+        case (this.state.country + 2) % locationData.length:
+          return { ...line, key: 2 };
+      }
+      return false;
+    }).filter(line => line)
+      .sort((line_a, line_b) => line_a.key - line_b.key);
 
     return (
       <section>

--- a/src/ui/shape/demo/app.jsx
+++ b/src/ui/shape/demo/app.jsx
@@ -68,6 +68,12 @@ class App extends React.Component {
     this.setState({ country: (this.state.country + 1) % locationData.length });
   }
 
+  getCurrentLocationData() {
+    return data.filter(
+      datum => datum.location === locationData[this.state.country].location,
+    );
+  }
+
   onClick(event, datum) {
     console.log(`${event.type}::${datum[keyField]},${datum[valueField]}`);
     this.setState({
@@ -113,9 +119,7 @@ class App extends React.Component {
           <YAxis />
           <Line
             animate
-            data={data.filter(
-              datum => datum.location === locationData[this.state.country].location,
-            )}
+            data={this.getCurrentLocationData()}
             dataAccessors={{ x: 'year_id', y: 'population' }}
             scales={{ x: scaleLinear(), y: scaleLinear() }}
           />
@@ -264,9 +268,7 @@ class App extends React.Component {
               <Scatter
                 animate
                 fill="steelblue"
-                data={data.filter(
-                  datum => datum.location === locationData[this.state.country].location,
-                )}
+                data={this.getCurrentLocationData()}
                 dataAccessors={{
                   fill: keyField,
                   key: keyField,

--- a/src/ui/shape/demo/index.html
+++ b/src/ui/shape/demo/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Scatter Plot Demo</title>
+  <title>Line and Scatter Plot Demo</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css">
   <style>
     html, body {

--- a/src/ui/shape/src/area.jsx
+++ b/src/ui/shape/src/area.jsx
@@ -7,12 +7,15 @@ import bindAll from 'lodash/bindAll';
 import partial from 'lodash/partial';
 
 import {
-  animationProcessorFactory,
-  CommonPropTypes,
+  AnimateEvents,
+  AnimateProp,
+  AnimateTiming,
   CommonDefaultProps,
+  CommonPropTypes,
+  animationProcessorFactory,
   memoizeByLastCall,
-  propsChanged,
   propResolver,
+  propsChanged,
   stateFromPropUpdates,
 } from '../../../utils';
 
@@ -127,6 +130,22 @@ export default class Area extends React.PureComponent {
 }
 
 Area.propTypes = {
+  /**
+   * Whether to animate the Area component (using default `start`, `update` functions).
+   * Optionally, an object that provides functions that dictate behavior of animations.
+   */
+  animate: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      events: AnimateEvents,
+      d: AnimateProp,
+      fill: AnimateProp,
+      stroke: AnimateProp,
+      strokeWidth: AnimateProp,
+      timing: AnimateTiming,
+    }),
+  ]),
+
   /**
    * className applied to path.
    */

--- a/src/ui/shape/src/area.jsx
+++ b/src/ui/shape/src/area.jsx
@@ -217,9 +217,9 @@ Area.animatable = [
 
 Area.processStyle = (style, { fill, stroke, strokeWidth }) => ({
   ...style,
-  fill: fill || style.fill,
-  stroke: stroke || style.stroke,
-  strokeWidth: strokeWidth || style.strokeWidth,
+  fill,
+  stroke,
+  strokeWidth,
 });
 
 Area.getPathGenerator = props => {

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -82,6 +82,7 @@ export default class Line extends React.PureComponent {
     const {
       className,
       clipPathId,
+      style,
     } = this.props;
 
     return (
@@ -94,7 +95,7 @@ export default class Line extends React.PureComponent {
         onMouseLeave={this.onMouseLeave}
         onMouseMove={this.onMouseMove}
         onMouseOver={this.onMouseOver}
-        style={this.processStyle(this.props.style, processedProps)}
+        style={this.processStyle(style, processedProps)}
       />
     );
   }
@@ -138,7 +139,7 @@ Line.propTypes = {
     PropTypes.bool,
     PropTypes.shape({
       events: AnimateEvents,
-      path: AnimateProp,
+      d: AnimateProp,
       stroke: AnimateProp,
       strokeWidth: AnimateProp,
       timing: AnimateTiming,

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Animate from 'react-move/Animate';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { line } from 'd3';
@@ -26,6 +27,7 @@ export default class Line extends React.PureComponent {
       'onMouseLeave',
       'onMouseMove',
       'onMouseOver',
+      'renderPath',
     ]);
   }
 
@@ -69,7 +71,11 @@ export default class Line extends React.PureComponent {
     onMouseOver(event, data, this);
   }
 
-  render() {
+  shouldAnimate() {
+    return !!this.props.animate;
+  }
+
+  renderPath(additionalProps) {
     const {
       className,
       clipPathId,
@@ -91,7 +97,28 @@ export default class Line extends React.PureComponent {
         onMouseMove={this.onMouseMove}
         onMouseOver={this.onMouseOver}
         style={style}
+        {...additionalProps}
       />
+    );
+  }
+
+  renderAnimatedPath() {
+    const { path } = this.state;
+    return (
+      <Animate
+        start={{ d: this.state.path }}
+        update={{ d: [path] }}
+      >
+        {this.renderPath}
+      </Animate>
+    );
+  }
+
+  render() {
+    return (
+      this.shouldAnimate()
+        ? this.renderAnimatedPath()
+        : this.renderPath()
     );
   }
 }

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -8,6 +8,9 @@ import partial from 'lodash/partial';
 
 import {
   animationProcessorFactory,
+  AnimateEvents,
+  AnimateProp,
+  AnimateTiming,
   CommonPropTypes,
   CommonDefaultProps,
   memoizeByLastCall,
@@ -127,6 +130,21 @@ export default class Line extends React.PureComponent {
 }
 
 Line.propTypes = {
+  /**
+   * Whether to animate the scatter component (using default `start`, `update` functions).
+   * Optionally, an object that provides functions that dictate behavior of animations.
+   */
+  animate: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      events: AnimateEvents,
+      path: AnimateProp,
+      stroke: AnimateProp,
+      strokeWidth: AnimateProp,
+      timing: AnimateTiming,
+    }),
+  ]),
+
   /**
    * className applied to path.
    */

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -233,8 +233,8 @@ Line.animatable = [
 
 Line.processStyle = (style, { stroke, strokeWidth }) => ({
   ...style,
-  stroke: stroke || style.stroke,
-  strokeWidth: strokeWidth || style.strokeWidth,
+  stroke,
+  strokeWidth,
 });
 
 Line.getPathGenerator = props => {

--- a/src/ui/shape/src/line.jsx
+++ b/src/ui/shape/src/line.jsx
@@ -132,7 +132,7 @@ export default class Line extends React.PureComponent {
 
 Line.propTypes = {
   /**
-   * Whether to animate the scatter component (using default `start`, `update` functions).
+   * Whether to animate the Line component (using default `start`, `update` functions).
    * Optionally, an object that provides functions that dictate behavior of animations.
    */
   animate: PropTypes.oneOfType([

--- a/src/ui/shape/src/multi-line.jsx
+++ b/src/ui/shape/src/multi-line.jsx
@@ -7,6 +7,7 @@ import { map, pick } from 'lodash';
 import Line from './line';
 import Area from './area';
 import {
+  AnimateEvents, AnimateProp, AnimateTiming,
   CommonDefaultProps,
   CommonPropTypes,
   propResolver,
@@ -46,6 +47,7 @@ export default class MultiLine extends React.PureComponent {
     } = fieldAccessors;
 
     const childProps = pick(this.props, [
+      'animate',
       'onClick',
       'onMouseLeave',
       'onMouseMove',
@@ -113,6 +115,21 @@ export default class MultiLine extends React.PureComponent {
 }
 
 MultiLine.propTypes = {
+  /**
+   * Whether to animate the scatter component (using default `start`, `update` functions).
+   * Optionally, an object that provides functions that dictate behavior of animations.
+   */
+  animate: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      events: AnimateEvents,
+      d: AnimateProp,
+      stroke: AnimateProp,
+      strokeWidth: AnimateProp,
+      timing: AnimateTiming,
+    }),
+  ]),
+
   /**
    * classname applied to `<Area/>`s that are children of MultiLine, if applicable
    */

--- a/src/ui/shape/src/multi-line.jsx
+++ b/src/ui/shape/src/multi-line.jsx
@@ -122,8 +122,8 @@ MultiLine.propTypes = {
   animate: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.shape({
-      events: AnimateEvents,
       d: AnimateProp,
+      events: AnimateEvents,
       stroke: AnimateProp,
       strokeWidth: AnimateProp,
       timing: AnimateTiming,

--- a/src/ui/shape/test/area.test.js
+++ b/src/ui/shape/test/area.test.js
@@ -54,6 +54,7 @@ describe('<Area />', () => {
     onMouseMove: eventHandler,
     onMouseOver: eventHandler,
     style: {
+      background: 'never overridden',
       fill: 'salmon',
       stroke: 'firebrick',
       strokeWidth: 5,
@@ -61,6 +62,7 @@ describe('<Area />', () => {
   };
 
   const processedStyle = {
+    background: 'will not override',
     fill: 'orangered',
     stroke: 'rebeccapurple',
     strokeWidth: 1000,
@@ -109,6 +111,16 @@ describe('<Area />', () => {
       expect(result2.fill).to.equal(processedStyle.fill);
       expect(result2.stroke).to.equal(processedStyle.stroke);
       expect(result2.strokeWidth).to.equal(processedStyle.strokeWidth);
+    });
+  });
+
+  describe('processStyle', () => {
+    it('combines props `style`, `stroke`, `strokeWidth` with existing style', () => {
+      const result = Area.processStyle(sharedProps.style, processedStyle);
+      expect(result.stroke).to.equal(processedStyle.stroke);
+      expect(result.strokeWidth).to.equal(processedStyle.strokeWidth);
+      expect(result.background).to.equal(sharedProps.style.background);
+      expect(result.background).not.to.equal(processedStyle.background);
     });
   });
 

--- a/src/ui/shape/test/area.test.js
+++ b/src/ui/shape/test/area.test.js
@@ -132,16 +132,16 @@ describe('<Area />', () => {
       with event, data, and the React element (${animated})`, () => {
         let wrapper = shallow(testComponent);
         const inst = wrapper.instance();
-        const event = {
-          preventDefault() {
-          },
-        };
 
         // If wrapped in <Animate /> it's necessary to `dive` an additional
         // layer in order to test simulated events consistently.
         if (testComponent.props.animate) {
           wrapper = wrapper.find(Animate).dive();
         }
+
+        const event = {
+          preventDefault() {},
+        };
 
         ['click', 'mouseLeave', 'mouseMove', 'mouseOver'].forEach((evtName) => {
           eventHandler.reset();

--- a/src/ui/shape/test/area.test.js
+++ b/src/ui/shape/test/area.test.js
@@ -53,6 +53,17 @@ describe('<Area />', () => {
     onMouseLeave: eventHandler,
     onMouseMove: eventHandler,
     onMouseOver: eventHandler,
+    style: {
+      fill: 'salmon',
+      stroke: 'firebrick',
+      strokeWidth: 5,
+    },
+  };
+
+  const processedStyle = {
+    fill: 'orangered',
+    stroke: 'rebeccapurple',
+    strokeWidth: 1000,
   };
 
   const components = [
@@ -75,6 +86,29 @@ describe('<Area />', () => {
       const path = wrapper.find('path');
       expect(path).to.have.length(1);
       expect(path).to.have.attr('d', expectedPath);
+    });
+  });
+
+  describe('dataProcessor', () => {
+    const result1 = Area.dataProcessor(sharedProps, sharedProps.data);
+    const result2 = Area.dataProcessor(
+      { ...sharedProps, style: processedStyle },
+      sharedProps.data,
+    );
+
+    it('returns calculated d attribute based on data accessors', () => {
+      // Close to above test, but intended to target `Area.dataProcessor` as a unit.
+      expect(result1.d).to.equal(expectedPath);
+      expect(result2.d).to.equal(expectedPath);
+    });
+
+    it('returns processed `fill`, `stroke`, `strokeWidth` properties', () => {
+      expect(result1.fill).to.equal(sharedProps.style.fill);
+      expect(result1.stroke).to.equal(sharedProps.style.stroke);
+      expect(result1.strokeWidth).to.equal(sharedProps.style.strokeWidth);
+      expect(result2.fill).to.equal(processedStyle.fill);
+      expect(result2.stroke).to.equal(processedStyle.stroke);
+      expect(result2.strokeWidth).to.equal(processedStyle.strokeWidth);
     });
   });
 

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 import { maxBy, minBy } from 'lodash';
 import { line, scalePoint, scaleLinear } from 'd3';
@@ -25,8 +25,6 @@ describe('<Line />', () => {
     length: 10,
   });
 
-  let component;
-
   const range = [minBy(data, valueField)[valueField], maxBy(data, valueField)[valueField]];
   const domain = [minBy(data, keyField)[keyField], maxBy(data, keyField)[keyField]];
 
@@ -41,26 +39,34 @@ describe('<Line />', () => {
 
   const expectedPath = lineFunction(data);
 
-  before(() => {
-    component = (
-      <Line
-        data={data}
-        scales={{ x: xScale, y: yScale }}
-        dataAccessors={{ x: keyField, y: valueField }}
-        onClick={eventHandler}
-        onMouseLeave={eventHandler}
-        onMouseMove={eventHandler}
-        onMouseOver={eventHandler}
-      />
-    );
-  });
+  const sharedProps = {
+    data,
+    scales: { x: xScale, y: yScale },
+    dataAccessors: { x: keyField, y: valueField },
+    onClick: eventHandler,
+    onMouseLeave: eventHandler,
+    onMouseMove: eventHandler,
+    onMouseOver: eventHandler,
+  };
 
-  it('renders an SVG path node with a d attribute', () => {
-    const wrapper = shallow(component);
-    const path = wrapper.find('path');
 
-    expect(path).to.have.length(1);
-    expect(path).to.have.attr('d', expectedPath);
+  const components = [
+    <Line {...sharedProps} />,
+    <Line animate {...sharedProps} />,
+  ];
+
+  describe('renders', () => {
+    components.forEach((testComponent) => {
+      const animated = testComponent.props.animate ? 'animated' : 'non-animated';
+
+      it(`an SVG path node with a d attribute (${animated})`, () => {
+        const wrapper = mount(testComponent);
+        const path = wrapper.find('path');
+
+        expect(path).to.have.length(1);
+        expect(path).to.have.attr('d', expectedPath);
+      });
+    });
   });
 
   describe('styling', () => {

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -41,6 +41,7 @@ describe('<Line />', () => {
   const expectedPath = lineFunction(data);
 
   const sharedProps = {
+    className: 'base-classname',
     data,
     scales: { x: xScale, y: yScale },
     dataAccessors: { x: keyField, y: valueField },
@@ -48,8 +49,11 @@ describe('<Line />', () => {
     onMouseLeave: eventHandler,
     onMouseMove: eventHandler,
     onMouseOver: eventHandler,
+    style: {
+      stroke: 'red',
+      strokeWidth: '10',
+    },
   };
-
 
   const components = [
     <Line {...sharedProps} />,
@@ -59,52 +63,26 @@ describe('<Line />', () => {
   describe('renders', () => {
     components.forEach((testComponent) => {
       const animated = testComponent.props.animate ? 'animated' : 'non-animated';
+      const wrapper = mount(testComponent);
 
-      it(`an SVG path node with a d attribute (${animated})`, () => {
-        const wrapper = mount(testComponent);
+      it(`SVG path node with a d attribute (${animated})`, () => {
         const path = wrapper.find('path');
 
         expect(path).to.have.length(1);
         expect(path).to.have.attr('d', expectedPath);
       });
+
+      it(`applies a base classname (${animated})`, () => {
+        expect(wrapper).to.have.className(sharedProps.className);
+      });
+
+      it(`applies style as an object (${animated})`, () => {
+        expect(wrapper).to.have.style('stroke', sharedProps.style.stroke);
+        expect(wrapper).to.have.style('stroke-width', sharedProps.style.strokeWidth);
+      });
     });
   });
 
-  describe('styling', () => {
-    const baseStyle = {
-      stroke: 'red',
-      strokeWidth: 10,
-    };
-
-    it('applies style as an object', () => {
-      const wrapper = shallow(
-        <Line
-          data={data}
-          scales={{ x: xScale, y: yScale }}
-          dataAccessors={{ x: keyField, y: valueField }}
-          style={baseStyle}
-        />
-      );
-
-      expect(wrapper).to.have.style('stroke', 'red');
-      expect(wrapper).to.have.style('stroke-width', '10');
-    });
-  });
-
-  describe('classnames', () => {
-    const wrapper = shallow(
-      <Line
-        className="base-classname"
-        data={data}
-        scales={{ x: xScale, y: yScale }}
-        dataAccessors={{ x: keyField, y: valueField }}
-      />
-    );
-
-    it('applies a base classname', () => {
-      expect(wrapper).to.have.className('base-classname');
-    });
-  });
 
   describe('events', () => {
     components.forEach((testComponent) => {
@@ -114,6 +92,9 @@ describe('<Line />', () => {
       the browser event, the data prop, and the React element (${animated})`, () => {
         let wrapper = shallow(testComponent);
         const inst = wrapper.instance();
+
+        // If wrapped in <Animate /> it's necessary to `dive` an additional
+        // layer in order to test simulated events consistently.
         if (testComponent.props.animate) {
           wrapper = wrapper.find(Animate).dive();
         }

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -67,7 +67,7 @@ describe('<Line />', () => {
     <Line animate {...sharedProps} />,
   ];
 
-  describe('renders', () => {
+  describe('render', () => {
     components.forEach((testComponent) => {
       const animated = testComponent.props.animate ? 'animated' : 'non-animated';
       const wrapper = mount(testComponent);

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -55,6 +55,11 @@ describe('<Line />', () => {
     },
   };
 
+  const additionalProps = {
+    stroke: 'blue',
+    strokeWidth: 1000,
+  };
+
   const components = [
     <Line {...sharedProps} />,
     <Line animate {...sharedProps} />,
@@ -83,6 +88,46 @@ describe('<Line />', () => {
     });
   });
 
+  describe('dataProcessor', () => {
+    const result1 = Line.dataProcessor(sharedProps, sharedProps.data);
+
+    const result2 = Line.dataProcessor(
+      { ...sharedProps, ...additionalProps },
+      sharedProps.data
+    );
+
+    it('returns calculated d attribute based on data accessors', () => {
+      // Close to above test, but intended to target `Line.dataProcessor` as a unit.
+      expect(result1.d).to.equal(expectedPath);
+    });
+
+    it('returns processed `stroke`, `strokeWidth` properties', () => {
+      // Nested in prop `style`
+      expect(result1.stroke).to.equal(sharedProps.style.stroke);
+      expect(result1.strokeWidth).to.equal(sharedProps.style.strokeWidth);
+      // From flat props `stroke`, `strokeWidth`
+      expect(result2.stroke).to.equal(additionalProps.stroke);
+      expect(result2.strokeWidth).to.equal(additionalProps.strokeWidth);
+    });
+  });
+
+  describe('processStyle', () => {
+    it('combines props `style`, `stroke`, `strokeWidth`', () => {
+      const result1 = Line.processStyle(sharedProps.style, additionalProps);
+      const result2 = Line.processStyle(
+        sharedProps.style,
+        { stroke: additionalProps.stroke },
+      );
+
+      // Flat props of `additionalProps` override those of `style`
+      expect(result1.stroke).to.equal(additionalProps.stroke);
+      expect(result1.strokeWidth).to.equal(additionalProps.strokeWidth);
+
+      // `stroke` overrides, while `strokeWidth` remains from `style`
+      expect(result2.stroke).to.equal(additionalProps.stroke);
+      expect(result2.strokeWidth).to.equal(sharedProps.style.strokeWidth);
+    });
+  });
 
   describe('events', () => {
     components.forEach((testComponent) => {

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -50,12 +50,14 @@ describe('<Line />', () => {
     onMouseMove: eventHandler,
     onMouseOver: eventHandler,
     style: {
+      background: 'never overridden',
       stroke: 'red',
       strokeWidth: '10',
     },
   };
 
   const processedStyle = {
+    background: 'will not override',
     stroke: 'blue',
     strokeWidth: 1000,
   };
@@ -115,6 +117,8 @@ describe('<Line />', () => {
       const result = Line.processStyle(sharedProps.style, processedStyle);
       expect(result.stroke).to.equal(processedStyle.stroke);
       expect(result.strokeWidth).to.equal(processedStyle.strokeWidth);
+      expect(result.background).to.equal(sharedProps.style.background);
+      expect(result.background).not.to.equal(processedStyle.background);
     });
   });
 

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -72,7 +72,7 @@ describe('<Line />', () => {
       const animated = testComponent.props.animate ? 'animated' : 'non-animated';
       const wrapper = mount(testComponent);
 
-      it(`SVG path node with a d attribute (${animated})`, () => {
+      it(`renders an SVG path node with a d attribute (${animated})`, () => {
         const path = wrapper.find('path');
 
         expect(path).to.have.length(1);

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -55,7 +55,7 @@ describe('<Line />', () => {
     },
   };
 
-  const additionalProps = {
+  const processedStyle = {
     stroke: 'blue',
     strokeWidth: 1000,
   };
@@ -92,40 +92,29 @@ describe('<Line />', () => {
     const result1 = Line.dataProcessor(sharedProps, sharedProps.data);
 
     const result2 = Line.dataProcessor(
-      { ...sharedProps, ...additionalProps },
+      { ...sharedProps, style: processedStyle },
       sharedProps.data
     );
 
     it('returns calculated d attribute based on data accessors', () => {
       // Close to above test, but intended to target `Line.dataProcessor` as a unit.
       expect(result1.d).to.equal(expectedPath);
+      expect(result2.d).to.equal(expectedPath);
     });
 
     it('returns processed `stroke`, `strokeWidth` properties', () => {
-      // Nested in prop `style`
       expect(result1.stroke).to.equal(sharedProps.style.stroke);
       expect(result1.strokeWidth).to.equal(sharedProps.style.strokeWidth);
-      // From flat props `stroke`, `strokeWidth`
-      expect(result2.stroke).to.equal(additionalProps.stroke);
-      expect(result2.strokeWidth).to.equal(additionalProps.strokeWidth);
+      expect(result2.stroke).to.equal(processedStyle.stroke);
+      expect(result2.strokeWidth).to.equal(processedStyle.strokeWidth);
     });
   });
 
   describe('processStyle', () => {
     it('combines props `style`, `stroke`, `strokeWidth`', () => {
-      const result1 = Line.processStyle(sharedProps.style, additionalProps);
-      const result2 = Line.processStyle(
-        sharedProps.style,
-        { stroke: additionalProps.stroke },
-      );
-
-      // Flat props of `additionalProps` override those of `style`
-      expect(result1.stroke).to.equal(additionalProps.stroke);
-      expect(result1.strokeWidth).to.equal(additionalProps.strokeWidth);
-
-      // `stroke` overrides, while `strokeWidth` remains from `style`
-      expect(result2.stroke).to.equal(additionalProps.stroke);
-      expect(result2.strokeWidth).to.equal(sharedProps.style.strokeWidth);
+      const result = Line.processStyle(sharedProps.style, processedStyle);
+      expect(result.stroke).to.equal(processedStyle.stroke);
+      expect(result.strokeWidth).to.equal(processedStyle.strokeWidth);
     });
   });
 

--- a/src/ui/shape/test/line.test.js
+++ b/src/ui/shape/test/line.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Animate from 'react-move/Animate';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount, shallow } from 'enzyme';
@@ -106,19 +107,27 @@ describe('<Line />', () => {
   });
 
   describe('events', () => {
-    it(`calls onClick, mouseLeave, mouseMove, and mouseOver with
-    the browser event, the data prop, and the React element`, () => {
-      const wrapper = shallow(component);
-      const event = {
-        preventDefault() {},
-      };
-      const inst = wrapper.instance();
+    components.forEach((testComponent) => {
+      const animated = testComponent.props.animate ? 'animated' : 'non-animated';
 
-      ['click', 'mouseLeave', 'mouseMove', 'mouseOver'].forEach((evtName) => {
-        eventHandler.reset();
-        wrapper.simulate(evtName, event);
-        expect(eventHandler.calledOnce).to.be.true;
-        expect(eventHandler.calledWith(event, data, inst)).to.be.true;
+      it(`calls onClick, mouseLeave, mouseMove, and mouseOver with
+      the browser event, the data prop, and the React element (${animated})`, () => {
+        let wrapper = shallow(testComponent);
+        const inst = wrapper.instance();
+        if (testComponent.props.animate) {
+          wrapper = wrapper.find(Animate).dive();
+        }
+
+        const event = {
+          preventDefault() {},
+        };
+
+        ['click', 'mouseLeave', 'mouseMove', 'mouseOver'].forEach((evtName) => {
+          eventHandler.reset();
+          wrapper.simulate(evtName, event);
+          expect(eventHandler.calledOnce).to.be.true;
+          expect(eventHandler.calledWith(event, data, inst)).to.be.true;
+        });
       });
     });
   });

--- a/src/ui/shape/test/multi-line.test.js
+++ b/src/ui/shape/test/multi-line.test.js
@@ -32,6 +32,9 @@ describe('<MultiLine />', () => {
 
   const lineData = [{ location: 'USA', values: data }, { location: 'Canada', values: data }];
 
+  const lineDataAccessors = { x: keyField, y: valueField };
+  const areaDataAccessors = { x: keyField, y0: 'value_lb', y1: 'value_ub' };
+
   const sharedProps = {
     data: lineData,
     fieldAccessors: {
@@ -43,103 +46,76 @@ describe('<MultiLine />', () => {
   };
 
   describe('plot of only <Line /> components', () => {
-    let component;
-
-    before(() => {
-      component = (
-        <MultiLine
-          {...sharedProps}
-          dataAccessors={{ x: keyField, y: valueField }}
-        />
-      );
-    });
+    const wrapper = shallow((
+      <MultiLine
+        {...sharedProps}
+        dataAccessors={lineDataAccessors}
+      />
+    ));
 
     it('renders a g', () => {
-      const wrapper = shallow(component);
       expect(wrapper.find('g')).to.have.length(1);
     });
 
     it('renders two <Line /> components', () => {
-      const wrapper = shallow(component);
       expect(wrapper).to.have.exactly(2).descendants('Line');
     });
 
     it('passes a subset of its props to child components', () => {
-      const wrapper = shallow(component);
       const child = wrapper.find('Line').first();
       expect(child)
         .to.have.prop('scales')
         .that.is.an('object')
         .that.has.keys(['x', 'y']);
 
-      expect(child)
-        .to.not.have.prop('keyField');
+      expect(child).to.not.have.prop('keyField');
     });
 
     it('alters styling passed to children when given a color scale', () => {
-      const wrapper = shallow(component);
       const usaLine = wrapper.find('Line').first();
       const caLine = wrapper.find('Line').last();
 
-      expect(usaLine)
-        .to.have.style('stroke', colorScale('USA'));
-
-      expect(caLine)
-        .to.have.style('stroke', colorScale('Canada'));
+      expect(usaLine).to.have.style('stroke', colorScale('USA'));
+      expect(caLine).to.have.style('stroke', colorScale('Canada'));
     });
   });
 
   describe('plot of only <Area /> components', () => {
-    let component;
-
-    before(() => {
-      component = (
-        <MultiLine
-          {...sharedProps}
-          dataAccessors={{ x: keyField, y0: 'value_lb', y1: 'value_ub' }}
-        />
-      );
-    });
+    const wrapper = shallow((
+      <MultiLine
+        {...sharedProps}
+        dataAccessors={areaDataAccessors}
+      />
+    ));
 
     it('renders two <Area /> components', () => {
-      const wrapper = shallow(component);
       expect(wrapper).to.have.exactly(2).descendants('Area');
     });
   });
 
   describe('plot of both <Line /> and <Area /> components', () => {
-    let component;
-
-    before(() => {
-      component = (
-        <MultiLine
-          {...sharedProps}
-          dataAccessors={{ x: keyField, y: valueField, y0: 'value_lb', y1: 'value_ub' }}
-        />
-      );
-    });
+    const wrapper = shallow((
+      <MultiLine
+        {...sharedProps}
+        dataAccessors={{ ...lineDataAccessors, ...areaDataAccessors }}
+      />
+    ));
 
     it('renders two <Line /> and two <Area /> components', () => {
-      const wrapper = shallow(component);
       expect(wrapper).to.have.exactly(2).descendants('Line');
       expect(wrapper).to.have.exactly(2).descendants('Area');
     });
   });
 
   describe('plot of neither <Line /> nor <Area />', () => {
-    let component;
-
-    before(() => {
-      component = (
-        <MultiLine
-          {...sharedProps}
-          dataAccessors={{ x: keyField }}
-        />
-      );
-    });
+    const wrapper = shallow((
+      <MultiLine
+        {...sharedProps}
+        dataAccessors={{ x: keyField }}
+      />
+    ));
 
     it('render neither <Line /> nor <Area /> components', () => {
-      const wrapper = shallow(component);
       expect(wrapper).to.not.have.descendants('Line');
       expect(wrapper).to.not.have.descendants('Area');
     });

--- a/src/ui/shape/test/multi-line.test.js
+++ b/src/ui/shape/test/multi-line.test.js
@@ -32,19 +32,23 @@ describe('<MultiLine />', () => {
 
   const lineData = [{ location: 'USA', values: data }, { location: 'Canada', values: data }];
 
+  const sharedProps = {
+    data: lineData,
+    fieldAccessors: {
+      key: 'location',
+      data: 'values',
+    },
+    scales,
+    colorScale,
+  };
+
   describe('plot of only <Line /> components', () => {
     let component;
 
     before(() => {
       component = (
         <MultiLine
-          data={lineData}
-          fieldAccessors={{
-            key: 'location',
-            data: 'values',
-          }}
-          scales={scales}
-          colorScale={colorScale}
+          {...sharedProps}
           dataAccessors={{ x: keyField, y: valueField }}
         />
       );
@@ -91,13 +95,7 @@ describe('<MultiLine />', () => {
     before(() => {
       component = (
         <MultiLine
-          data={lineData}
-          fieldAccessors={{
-            key: 'location',
-            data: 'values',
-          }}
-          scales={scales}
-          colorScale={colorScale}
+          {...sharedProps}
           dataAccessors={{ x: keyField, y0: 'value_lb', y1: 'value_ub' }}
         />
       );
@@ -115,13 +113,7 @@ describe('<MultiLine />', () => {
     before(() => {
       component = (
         <MultiLine
-          data={lineData}
-          fieldAccessors={{
-            key: 'location',
-            data: 'values',
-          }}
-          scales={scales}
-          colorScale={colorScale}
+          {...sharedProps}
           dataAccessors={{ x: keyField, y: valueField, y0: 'value_lb', y1: 'value_ub' }}
         />
       );
@@ -140,13 +132,7 @@ describe('<MultiLine />', () => {
     before(() => {
       component = (
         <MultiLine
-          data={lineData}
-          fieldAccessors={{
-            key: 'location',
-            data: 'values',
-          }}
-          scales={scales}
-          colorScale={colorScale}
+          {...sharedProps}
           dataAccessors={{ x: keyField }}
         />
       );

--- a/src/ui/shape/test/multi-line.test.js
+++ b/src/ui/shape/test/multi-line.test.js
@@ -152,6 +152,31 @@ describe('<MultiLine />', () => {
       });
     });
   });
+
+  describe('passes specified properties to its children', () => {
+    it('passes specified properties to its children', () => {
+      const inheritedProps = [
+        'animate',
+        'onClick',
+        'onMouseLeave',
+        'onMouseMove',
+        'onMouseOver',
+      ];
+
+      const assertion = (shape) => {
+        inheritedProps.forEach((prop) => {
+          expect(shape).to.have.prop(prop);
+        });
+      };
+
+      const wrapper = shallow((
+        <MultiLine
+          {...sharedProps}
+          dataAccessors={{ ...lineDataAccessors, ...areaDataAccessors }}
+        />
+      ));
+
+      wrapper.find('line').forEach(assertion);
     });
   });
 });

--- a/src/ui/shape/test/multi-line.test.js
+++ b/src/ui/shape/test/multi-line.test.js
@@ -163,12 +163,6 @@ describe('<MultiLine />', () => {
         'onMouseOver',
       ];
 
-      const assertion = (shape) => {
-        inheritedProps.forEach((prop) => {
-          expect(shape).to.have.prop(prop);
-        });
-      };
-
       const wrapper = shallow((
         <MultiLine
           {...sharedProps}
@@ -176,7 +170,11 @@ describe('<MultiLine />', () => {
         />
       ));
 
-      wrapper.find('line').forEach(assertion);
+      wrapper.find('line').forEach((shape) => {
+        inheritedProps.forEach((prop) => {
+          expect(shape).to.have.prop(prop);
+        });
+      });
     });
   });
 });

--- a/src/ui/shape/test/multi-line.test.js
+++ b/src/ui/shape/test/multi-line.test.js
@@ -46,78 +46,112 @@ describe('<MultiLine />', () => {
   };
 
   describe('plot of only <Line /> components', () => {
-    const wrapper = shallow((
-      <MultiLine
-        {...sharedProps}
-        dataAccessors={lineDataAccessors}
-      />
-    ));
+    const testProps = {
+      ...sharedProps,
+      dataAccessors: lineDataAccessors,
+    };
 
-    it('renders a g', () => {
-      expect(wrapper.find('g')).to.have.length(1);
-    });
+    const components = [
+      <MultiLine {...testProps} />,
+      <MultiLine animate {...testProps} />,
+    ];
 
-    it('renders two <Line /> components', () => {
-      expect(wrapper).to.have.exactly(2).descendants('Line');
-    });
+    components.forEach((testComponent) => {
+      const animated = testComponent.props.animate ? 'animated' : 'non-animated';
+      const wrapper = shallow(testComponent);
 
-    it('passes a subset of its props to child components', () => {
-      const child = wrapper.find('Line').first();
-      expect(child)
-        .to.have.prop('scales')
-        .that.is.an('object')
-        .that.has.keys(['x', 'y']);
+      it(`renders a g (${animated})`, () => {
+        expect(wrapper.find('g')).to.have.length(1);
+      });
 
-      expect(child).to.not.have.prop('keyField');
-    });
+      it(`renders two <Line /> components (${animated})`, () => {
+        expect(wrapper).to.have.exactly(2).descendants('Line');
+      });
 
-    it('alters styling passed to children when given a color scale', () => {
-      const usaLine = wrapper.find('Line').first();
-      const caLine = wrapper.find('Line').last();
+      it(`passes a subset of its props to child components (${animated})`, () => {
+        const child = wrapper.find('Line').first();
+        expect(child)
+          .to.have.prop('scales')
+          .that.is.an('object')
+          .that.has.keys(['x', 'y']);
 
-      expect(usaLine).to.have.style('stroke', colorScale('USA'));
-      expect(caLine).to.have.style('stroke', colorScale('Canada'));
+        expect(child).to.not.have.prop('keyField');
+      });
+
+      it(`alters styling passed to children when given a color scale (${animated})`, () => {
+        const usaLine = wrapper.find('Line').first();
+        const caLine = wrapper.find('Line').last();
+
+        expect(usaLine).to.have.style('stroke', colorScale('USA'));
+        expect(caLine).to.have.style('stroke', colorScale('Canada'));
+      });
     });
   });
 
   describe('plot of only <Area /> components', () => {
-    const wrapper = shallow((
-      <MultiLine
-        {...sharedProps}
-        dataAccessors={areaDataAccessors}
-      />
-    ));
+    const testProps = {
+      ...sharedProps,
+      dataAccessors: areaDataAccessors,
+    };
 
-    it('renders two <Area /> components', () => {
-      expect(wrapper).to.have.exactly(2).descendants('Area');
+    const components = [
+      <MultiLine {...testProps} />,
+      <MultiLine animate {...testProps} />,
+    ];
+
+    components.forEach((testComponent) => {
+      const animated = testComponent.props.animate ? 'animated' : 'non-animated';
+      const wrapper = shallow(testComponent);
+
+      it(`renders two <Area /> components (${animated})`, () => {
+        expect(wrapper).to.have.exactly(2).descendants('Area');
+      });
     });
   });
 
   describe('plot of both <Line /> and <Area /> components', () => {
-    const wrapper = shallow((
-      <MultiLine
-        {...sharedProps}
-        dataAccessors={{ ...lineDataAccessors, ...areaDataAccessors }}
-      />
-    ));
+    const testProps = {
+      ...sharedProps,
+      dataAccessors: { ...lineDataAccessors, ...areaDataAccessors },
+    };
 
-    it('renders two <Line /> and two <Area /> components', () => {
-      expect(wrapper).to.have.exactly(2).descendants('Line');
-      expect(wrapper).to.have.exactly(2).descendants('Area');
+    const components = [
+      <MultiLine {...testProps} />,
+      <MultiLine animate {...testProps} />,
+    ];
+
+    components.forEach((testComponent) => {
+      const animated = testComponent.props.animate ? 'animated' : 'non-animated';
+      const wrapper = shallow(testComponent);
+
+      it(`renders two <Line /> and two <Area /> components (${animated})`, () => {
+        expect(wrapper).to.have.exactly(2).descendants('Line');
+        expect(wrapper).to.have.exactly(2).descendants('Area');
+      });
     });
   });
 
   describe('plot of neither <Line /> nor <Area />', () => {
-    const wrapper = shallow((
-      <MultiLine
-        {...sharedProps}
-        dataAccessors={{ x: keyField }}
-      />
-    ));
+    const testProps = {
+      ...sharedProps,
+      dataAccessors: { x: keyField },
+    };
 
-    it('render neither <Line /> nor <Area /> components', () => {
-      expect(wrapper).to.not.have.descendants('Line');
-      expect(wrapper).to.not.have.descendants('Area');
+    const components = [
+      <MultiLine {...testProps} />,
+      <MultiLine animate {...testProps} />,
+    ];
+
+    components.forEach((testComponent) => {
+      const animated = testComponent.props.animate ? 'animated' : 'non-animated';
+      const wrapper = shallow(testComponent);
+
+      it(`render neither <Line /> nor <Area /> components (${animated})`, () => {
+        expect(wrapper).to.not.have.descendants('Line');
+        expect(wrapper).to.not.have.descendants('Area');
+      });
+    });
+  });
     });
   });
 });

--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -27,10 +27,10 @@ export function animationStartFactory(animate, processor) {
 }
 
 export function getMethodIfExists(methodMap, key) {
-  const preliminaryMethod = get(methodMap, [key]);
+  const potentialMethod = get(methodMap, [key]);
   return (
-    typeof preliminaryMethod === 'function'
-    ? preliminaryMethod
+    typeof potentialMethod === 'function'
+    ? potentialMethod
     : null
   );
 }

--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -33,7 +33,7 @@ export function getMethodIfExists(methodMap, key) {
     ? preliminaryMethod
     : null
   );
-};
+}
 
 // A factory for each animation method: `enter` | `update` | `leave`;
 export function animationProcessorFactory(animate, animatableKeys, processor, method) {

--- a/src/utils/animate.js
+++ b/src/utils/animate.js
@@ -26,6 +26,15 @@ export function animationStartFactory(animate, processor) {
   };
 }
 
+export function getMethodIfExists(methodMap, key) {
+  const preliminaryMethod = get(methodMap, [key]);
+  return (
+    typeof preliminaryMethod === 'function'
+    ? preliminaryMethod
+    : null
+  );
+};
+
 // A factory for each animation method: `enter` | `update` | `leave`;
 export function animationProcessorFactory(animate, animatableKeys, processor, method) {
   const NON_ANIMATABLE_METHOD = 'start';
@@ -51,8 +60,12 @@ export function animationProcessorFactory(animate, animatableKeys, processor, me
           const events = get(specificAnimationMethods, [key, 'events'], rootEvents);
           const timing = get(specificAnimationMethods, [key, 'timing'], rootTiming);
 
+          // A user defined animation method, agnostic to animation phase.
+          // ie, `animate.fill`
+          const phaseAgnosticMethod = getMethodIfExists(specificAnimationMethods, key);
+
           // A user defined animation method. ie, `animate.fill.update`
-          const userMethod = get(specificAnimationMethods, [key, method]);
+          const userMethod = get(specificAnimationMethods, [key, method], phaseAgnosticMethod);
 
           // Apply animate defaults that can be overridden by user for respective `key`.
           const resolvedState = {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,7 @@
 export {
   animationProcessorFactory,
   animationStartFactory,
+  getMethodIfExists,
 } from './animate';
 
 export {

--- a/src/utils/test/animate.test.js
+++ b/src/utils/test/animate.test.js
@@ -11,6 +11,7 @@ import sinon from 'sinon';
 import {
   animationStartFactory,
   animationProcessorFactory,
+  getMethodIfExists,
 } from '../';
 
 describe('animate factory functions', () => {
@@ -132,6 +133,42 @@ describe('animate factory functions', () => {
       });
     });
   }
+
+  describe('getMethodIfExists', () => {
+    const methodMap = {
+      fill: noop,
+      stroke: {},
+    };
+
+    const foreseeableInputs = [false, true, undefined];
+    const unexpectedButPossibleInputs = [1, 2, 3, 'a', 'b', 'c'];
+
+    it('returns property when it is a function', () => {
+      const method = getMethodIfExists(methodMap, 'fill');
+      expect(method).to.be.a('function');
+    });
+
+    it('returns `null` when property is not a function', () => {
+      const method = getMethodIfExists(methodMap, 'stroke');
+      expect(method).to.equal(null);
+    });
+
+    it('gracefully handles unexpected inputs', () => {
+      unexpectedButPossibleInputs.forEach((unexpectedInput) => {
+        function shouldNotThrow() {
+          getMethodIfExists(unexpectedInput, 'key');
+        }
+        expect(shouldNotThrow).to.not.throw();
+      });
+    });
+
+    it('returns `null` when input is not an object', () => {
+      [...foreseeableInputs, ...unexpectedButPossibleInputs].forEach((nonObjectInput) => {
+        const method = getMethodIfExists(nonObjectInput, 'key');
+        expect(method).to.equal(null);
+      });
+    });
+  });
 
   describe('Default functionality (`animate` param is boolean):', () => {
     const animate = true;


### PR DESCRIPTION
This PR implements animation in the `<Line/>`, `<Area/>`, and `<MultiLine/>` components into the greater `react-move` animation effort branch of this repo. After this PR has been merged, I plan to make another PR to merge `react-move`  `=>`  `master`.

**Implementation details**
Animations are implemented using react-move's [`<Animate/>`](https://react-move.js.org/#/documentation/animate) wrapper since the `<Line/>` and `<Area/>` components essentially render a single `<path/>`. This differs from how `<Scatter />` was animated which uses react-move's [`<NodeGroup/>`](https://react-move.js.org/#/documentation/node-group) wrapper since it renders a _collection_ of `<Shape/>` components rather than a single component.

**Other PR notes**
- Existing unit testing scenarios have been extended to include when components are animated.
- Removal of deprecated property `ecmaFeatures` from .eslintrs.js since Intellij was notifying me to do so.
- Style tweaks in accordance with linting rules.
- Updated src/ui/shape/demo to include demos of animated **Line** and **Multi Line** charts, changed title of the demo to _Line and Scatter Plot Demo_.

Cheers!
-Jim