### PR TITLE
Bug fix - Fix styles for non-hierarchical options

### DIFF
--- a/src/ui/select/src/select-option-label.jsx
+++ b/src/ui/select/src/select-option-label.jsx
@@ -8,7 +8,9 @@ import { default as getValue } from 'lodash/get';
  */
 const flatOptionPropTypes = {
   // option object
-  option: PropTypes.object.isRequired,
+  option: PropTypes.shape({
+    bold: PropTypes.bool,
+  }),
 
   // key on option that holds its label
   labelKey: PropTypes.string.isRequired,

--- a/src/ui/select/src/select-option-label.jsx
+++ b/src/ui/select/src/select-option-label.jsx
@@ -15,7 +15,15 @@ const flatOptionPropTypes = {
 };
 
 export function FlatOptionLabel(props) {
-  return <span>{`${getValue(props.option, [props.labelKey], '')}`}</span>;
+  return (
+    <span
+      style={{
+        fontWeight: props.option.bold ? 'bold' : 'normal',
+      }}
+    >
+      {`${getValue(props.option, [props.labelKey], '')}`}
+    </span>
+  );
 }
 
 FlatOptionLabel.propTypes = flatOptionPropTypes;


### PR DESCRIPTION
The options don't bold as expected for non-hierarchical dropdowns because the styles are not being transferred to the DOM node.