### PR TITLE
Task/bar chart 18

### DIFF
--- a/src/ui/compositions/barchart/src/barchart.jsx
+++ b/src/ui/compositions/barchart/src/barchart.jsx
@@ -32,14 +32,14 @@ export default class BarChart extends PureComponent {
 
   renderTitle() {
     const {
-      labelObject,
+      labelAccessors,
       titleClassName,
       titleStyle,
     } = this.props;
-    if (!labelObject.title) return null;
+    if (!labelAccessors.title) return null;
     return (
       <div className={classNames(styles.title, titleClassName)} style={titleStyle}>
-        {labelObject.title}
+        {labelAccessors.title}
       </div>
     );
   }
@@ -74,14 +74,14 @@ export default class BarChart extends PureComponent {
       fill,
       focus,
       height,
-      labelObject,
+      labelAccessors,
       onClick,
       onMouseOver,
       onMouseLeave,
       onMouseMove,
       orientation,
       scaleObject,
-      bandObject,
+      bandPositions,
       width,
     } = this.props;
 
@@ -99,16 +99,16 @@ export default class BarChart extends PureComponent {
             yScaleType={scaleObject.yScale}
           >
             <XAxis
-              label={labelObject.xLabel ? labelObject.xLabel : 'X Axis'}
+              label={labelAccessors.xLabel}
             />
             <YAxis
-              label={labelObject.yLabel ? labelObject.yLabel : 'Y Axis'}
+              label={labelAccessors.yLabel}
             />
             <Bars
-              align={bandObject.align}
-              bandPaddingOuter={bandObject.bandPaddingOuter}
-              bandPadding={bandObject.bandPadding}
-              bandPaddingInner={bandObject.bandPaddingInner}
+              align={bandPositions.align}
+              bandPaddingOuter={bandPositions.bandPaddingOuter}
+              bandPadding={bandPositions.bandPadding}
+              bandPaddingInner={bandPositions.bandPaddingInner}
               dataAccessors={dataAccessors}
               data={data}
               fill={fill}
@@ -167,13 +167,13 @@ BarChart.propTypes = {
   bandPaddingOuter: PropTypes.number,
 
   /**
-   * Accessors to d3 scale band properties
-   *    align: property used to access the align property to alter d3 scaleBand alignment
-   *    bandPadding: property used to access the bandPadding to alter d3 scaleBand inner and outer padding
-   *    bandPaddingInner: property used to access the bandPaddingInner to alter d3 scaleBand inner padding
-   *    bandPaddingOuter: property used to access the bandPaddingOuter to alter d3 scaleBand outer padding
+   * Values used for the d3 scale band properties
+   *    align: property used for the align property to alter d3 scaleBand alignment
+   *    bandPadding: property used for the bandPadding to alter d3 scaleBand inner and outer padding
+   *    bandPaddingInner: property used for the bandPaddingInner to alter d3 scaleBand inner padding
+   *    bandPaddingOuter: property used for the bandPaddingOuter to alter d3 scaleBand outer padding
    */
-  bandObject: PropTypes.shape({
+  bandPositions: PropTypes.shape({
     align: PropTypes.number,
     bandPadding: PropTypes.number,
     bandPaddingInner: PropTypes.number,
@@ -226,7 +226,7 @@ BarChart.propTypes = {
    *    xLabel: property used to access the xLabel of the composite component
    *    yLabel: property used to access the yLabel of the composite component
    */
-  labelObject: PropTypes.shape({
+  labelAccessors: PropTypes.shape({
     title: PropTypes.string,
     xLabel: PropTypes.string,
     yLabel: PropTypes.string
@@ -320,7 +320,11 @@ BarChart.propTypes = {
 BarChart.defaultProps = {
   orientation: 'vertical',
   fill: 'steelblue',
-  bandObject: {
+  band: {
     align: 0.5
-  }
+  },
+  labelAccessors: {
+    xLabel: 'X Axis',
+    yLabel: 'Y Axis',
+  },
 };

--- a/src/ui/compositions/barchart/src/barchart.jsx
+++ b/src/ui/compositions/barchart/src/barchart.jsx
@@ -46,17 +46,17 @@ export default class BarChart extends PureComponent {
 
   renderLegend() {
     const {
-      legendObject,
+      legendAccessors,
       legendKey,
       legendClassName,
       legendStyle,
     } = this.props;
-    if (!legendObject) return null;
+    if (!legendAccessors) return null;
     return (
       <div className={classNames(styles.legend, legendClassName)} style={legendStyle}>
         <div className={styles['legend-wrapper']}>
           <Legend
-            items={legendObject}
+            items={legendAccessors}
             labelKey={legendKey.labelKey}
             shapeColorKey={legendKey.shapeColorKey}
             shapeTypeKey={legendKey.shapeTypeKey}
@@ -80,7 +80,7 @@ export default class BarChart extends PureComponent {
       onMouseLeave,
       onMouseMove,
       orientation,
-      scaleObject,
+      scaleAccessors,
       bandPositions,
       width,
     } = this.props;
@@ -93,10 +93,10 @@ export default class BarChart extends PureComponent {
           <AxisChart
             width={width}
             height={height}
-            xDomain={scaleObject.xDomain}
-            yDomain={scaleObject.yDomain}
-            xScaleType={scaleObject.xScale}
-            yScaleType={scaleObject.yScale}
+            xDomain={scaleAccessors.xDomain}
+            yDomain={scaleAccessors.yDomain}
+            xScaleType={scaleAccessors.xScale}
+            yScaleType={scaleAccessors.yScale}
           >
             <XAxis
               label={labelAccessors.xLabel}
@@ -238,7 +238,7 @@ BarChart.propTypes = {
    *    shapeColorKey: property used to access the path to shape color in item objects (e.g., 'color', 'properties.color')
    *    shapeTypeKey: property used to access the path to shape type in item objects (e.g., 'type', 'properties.type')
    */
-  legendObject: PropTypes.shape({
+  legendAccessors: PropTypes.shape({
     labelKey: PropTypes.string,
     shapeColorKey: PropTypes.string,
     shapeTypeKey: PropTypes.string
@@ -298,7 +298,7 @@ BarChart.propTypes = {
    *    xScale: property used to access the xScale  of the scales object
    *    yScale: property used to access the yScale of the scales object
    */
-  scaleObject: PropTypes.shape({
+  scaleAccessors: PropTypes.shape({
     xDomain: PropTypes.string,
     yDomain: PropTypes.string,
     xScale: PropTypes.string,


### PR DESCRIPTION
Line: 178, make documentation of bandObject more clear (it is NOT an accessor)
 - rename bandObject better (does not need 'object')

Line 231: change labelObject to labelAccessors