### PR TITLE
v0.32.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ihme-ui",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ihme-ui",
   "description": "Visualization tools from the Institute for Health Metrics and Evaluation",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "license": "MIT",
   "browser": "dist/ihme-ui.min.js",
   "main": "lib/index.js",


### PR DESCRIPTION
Immediately after fixing one vulnerability (node-mime) there was a warning of another (hoek). v0.32.2 fixes the latter of the two.