### PR TITLE
Make react a peer dep and a dev dep; make react-dom a dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9513,6 +9513,7 @@
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
       "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",
@@ -9572,6 +9573,7 @@
       "version": "16.2.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.1.tgz",
       "integrity": "sha512-0ujGgYnpX0GlaAjUfwU7ddy0DjuzPmTHHi2SlPolGv7hAyUpK7XA7WZcxit5ZcU7cW5QU1HJjlS3eMn42tSfYQ==",
+      "dev": true,
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,9 @@
     "mustache": "~2.3",
     "postcss": "^6.0.17",
     "postcss-loader": "^2.1.0",
+    "react": "^16.2.0",
     "react-docgen": "~2.13",
+    "react-dom": "^16.2.1",
     "react-test-renderer": "^16.2.0",
     "request": "~2.87.0",
     "sinon": "^2.4.1",
@@ -96,11 +98,12 @@
     "interact.js": "~1.2",
     "lodash": "^4.17.11",
     "prop-types": "~15.6",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.1",
     "react-move": "^2.7.0",
     "react-virtualized": "^9.18.5",
     "react-virtualized-select": "^3.1.3",
     "topojson": "^3.0.2"
+  },
+  "peerDependencies": {
+    "react": "16.x"
   }
 }


### PR DESCRIPTION
HME-UI's main exports are React components, so a user of the library must have a compatible version of React. React is also needed for development work, so it's a dev dependency too. react-dom is only used in demos, so it should be a dev dependency.

Information about `npm` peer dependencies: https://nodejs.org/en/blog/npm/peer-dependencies