### PR TITLE
Replace topojson package with topojson-client and topojson-simplify.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10909,41 +10909,21 @@
         }
       }
     },
-    "topojson": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/topojson/-/topojson-3.0.2.tgz",
-      "integrity": "sha512-u3zeuL6WEVL0dmsRn7uHZKc4Ao4gpW3sORUv+N3ezLTvY3JdCuyg0hvpWiIfFw8p/JwVN++SvAsFgcFEeR15rQ==",
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
       "requires": {
-        "topojson-client": "3.0.0",
-        "topojson-server": "3.0.0",
-        "topojson-simplify": "3.0.2"
-      },
-      "dependencies": {
-        "topojson-client": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
-          "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
-          "requires": {
-            "commander": "2"
-          }
-        },
-        "topojson-server": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
-          "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
-          "requires": {
-            "commander": "2"
-          }
-        },
-        "topojson-simplify": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/topojson-simplify/-/topojson-simplify-3.0.2.tgz",
-          "integrity": "sha512-gyYSVRt4jO/0RJXKZQPzTDQRWV+D/nOfiljNUv0HBXslFLtq3yxRHrl7jbrjdbda5Ytdr7M8BZUI4OxU7tnbRQ==",
-          "requires": {
-            "commander": "2",
-            "topojson-client": "3"
-          }
-        }
+        "commander": "2"
+      }
+    },
+    "topojson-simplify": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/topojson-simplify/-/topojson-simplify-3.0.2.tgz",
+      "integrity": "sha512-gyYSVRt4jO/0RJXKZQPzTDQRWV+D/nOfiljNUv0HBXslFLtq3yxRHrl7jbrjdbda5Ytdr7M8BZUI4OxU7tnbRQ==",
+      "requires": {
+        "commander": "2",
+        "topojson-client": "3"
       }
     },
     "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ihme-ui",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ihme-ui",
   "description": "Visualization tools from the Institute for Health Metrics and Evaluation",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "license": "MIT",
   "browser": "dist/ihme-ui.min.js",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "react-move": "^2.7.0",
     "react-virtualized": "^9.18.5",
     "react-virtualized-select": "^3.1.3",
-    "topojson": "^3.0.2"
+    "topojson-client": "^3.0.0",
+    "topojson-simplify": "^3.0.2"
   },
   "peerDependencies": {
     "react": "16.x"

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -10,7 +10,7 @@ import {
   zoomIdentity,
   zoomTransform,
 } from 'd3';
-import { presimplify } from 'topojson';
+import { presimplify } from 'topojson-simplify';
 import { bindAll, filter, has, isEqual, keyBy, memoize } from 'lodash';
 import {
   calcCenterPoint,

--- a/src/ui/choropleth/test/utils.js
+++ b/src/ui/choropleth/test/utils.js
@@ -1,4 +1,4 @@
-import * as topojson from 'topojson';
+import * as topojson from 'topojson-client';
 
 export const topology = {
   arcs: [

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -1,4 +1,4 @@
-import * as topojson from 'topojson';
+import * as topojson from 'topojson-client';
 import {
   concat,
   reduce,


### PR DESCRIPTION
As this issue (https://github.com/topojson/topojson/issues/304) on GitHub explains, `npm install` fails with an error if a project tries to include both `topojson` and `topojson-client`.  Because `topojson` is simply a light wrapper for the three subpackages `topojson-client`, `topojson-simplify`, and `topojson-server`, and IHME-UI only uses the first two of these, it seems simplest and most economical to replace the wrapper with the two constituent packages we're actually using.