### PR TITLE
Fix animate Scatter resize issue

### DIFF
--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -186,12 +186,8 @@ export default class Scatter extends React.PureComponent {
     );
   }
 
-  shouldAnimate() {
-    return (!!this.props.animate && !this.state.windowResize);
-  }
-
   render() {
-    if (this.shouldAnimate()) {
+    if (this.state.shouldAnimate) {
       return this.renderAnimatedScatter(this.state.sortedData);
     }
 
@@ -478,12 +474,12 @@ Scatter.propUpdates = {
       sortedData,
     };
   },
-  windowResize: (state, _, prevProps, nextProps) => {
+  shouldAnimate: (state, _, prevProps, nextProps) => {
     const prevWindowResize = [prevProps.height, prevProps.width];
     const nextWindowResize = [nextProps.height, nextProps.width];
     return {
       ...state,
-      windowResize: !isEqual(prevWindowResize, nextWindowResize),
+      shouldAnimate: (nextProps.animate && isEqual(prevWindowResize, nextWindowResize)),
     };
   },
 };

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -475,11 +475,11 @@ Scatter.propUpdates = {
     };
   },
   shouldAnimate: (state, _, prevProps, nextProps) => {
-    const prevWindowResize = [prevProps.height, prevProps.width];
-    const nextWindowResize = [nextProps.height, nextProps.width];
+    const prevWindowSize = [prevProps.height, prevProps.width];
+    const nextWindowSize = [nextProps.height, nextProps.width];
     return {
       ...state,
-      shouldAnimate: (nextProps.animate && isEqual(prevWindowResize, nextWindowResize)),
+      shouldAnimate: nextProps.animate && isEqual(prevWindowSize, nextWindowSize),
     };
   },
 };

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -6,6 +6,7 @@ import { scaleLinear } from 'd3';
 import {
   bindAll,
   findIndex,
+  isEqual,
   isFinite,
   has,
   keyBy,
@@ -186,7 +187,7 @@ export default class Scatter extends React.PureComponent {
   }
 
   shouldAnimate() {
-    return !!this.props.animate;
+    return (!!this.props.animate && !this.state.windowResize);
   }
 
   render() {
@@ -475,6 +476,14 @@ Scatter.propUpdates = {
     return {
       ...state,
       sortedData,
+    };
+  },
+  windowResize: (state, _, prevProps, nextProps) => {
+    const prevWindowResize = [prevProps.height, prevProps.width];
+    const nextWindowResize = [nextProps.height, nextProps.width];
+    return {
+      ...state,
+      windowResize: !isEqual(prevWindowResize, nextWindowResize),
     };
   },
 };


### PR DESCRIPTION
NodeGroup will only update when data changes, this means that it will not resize on window change until the data is also changing. To fix this issue I have made it so that we do not hit NodeGroup (renderAnimatedScatter) when the window is resized but will if the data is updated.