### PR TITLE
Axis format hotfix

### DIFF
--- a/src/ui/axis-chart/demo/app.jsx
+++ b/src/ui/axis-chart/demo/app.jsx
@@ -68,6 +68,11 @@ const axisStyle = {
   fontSize: '11px',
 };
 
+const labelStyle = {
+  fontFamily: 'sans-serif',
+  fontSize: '16px',
+}
+
 const dataAccessors = { x: keyField, y: valueField, y0: 'value_lb', y1: 'value_ub' };
 const chartClassName = ['foo', 'bar'];
 
@@ -158,9 +163,24 @@ class App extends React.Component {
               dataAccessors={dataAccessors}
               onClick={()=>{console.log('click')}}
             />
-            <XAxis style={axisStyle} label="Year" tickFormat={format("")} />
-            <XAxis style={axisStyle} label="Year" orientation="top" tickFormat={format("")} />
-            <YAxis style={axisStyle} label="Probability" />
+            <XAxis
+              style={axisStyle}
+              label="Year"
+              labelStyle={labelStyle}
+              tickFormat={format("")}
+            />
+            <XAxis
+              style={axisStyle}
+              label="Year"
+              labelStyle={labelStyle}
+              orientation="top"
+              tickFormat={format("")}
+            />
+            <YAxis
+              style={axisStyle}
+              label="Probability"
+              labelStyle={labelStyle}
+            />
           </AxisChart>
         </div>
       </div>

--- a/src/ui/axis-chart/demo/app.jsx
+++ b/src/ui/axis-chart/demo/app.jsx
@@ -125,9 +125,24 @@ class App extends React.Component {
                   dataAccessors={dataAccessors}
                   onClick={()=>{console.log('click')}}
                 />
-                <XAxis style={axisStyle} label="Year" tickFormat={format("")} />
-                <XAxis style={axisStyle} label="Year" orientation="top" tickFormat={format("")} />
-                <YAxis style={axisStyle} label="Probability" />
+                <XAxis
+                  style={axisStyle}
+                  label="Year"
+                  labelStyle={labelStyle}
+                  tickFormat={format("")}
+                />
+                <XAxis
+                  style={axisStyle}
+                  label="Year"
+                  labelStyle={labelStyle}
+                  orientation="top"
+                  tickFormat={format("")}
+                />
+                <YAxis
+                  style={axisStyle}
+                  label="Probability"
+                  labelStyle={labelStyle}
+                />
               </AxisChart>
             </code></pre> */}
         <div style={{ textAlign: 'center', marginBottom: '20px' }}>

--- a/src/ui/axis/src/axis.jsx
+++ b/src/ui/axis/src/axis.jsx
@@ -96,13 +96,13 @@ export default class Axis extends React.PureComponent {
 
     const axis = AXIS_TYPES[orientation](scale);
 
+    axis.tickSize(tickSize); // default is 6px
+    axis.tickPadding(tickPadding); // default is 3px
     if (ticks) axis.ticks(ticks);
     if (tickArguments) axis.tickArguments(tickArguments);
     if (tickFormat) axis.tickFormat(tickFormat);
-    if (tickSize) axis.tickSize(tickSize);
     if (tickSizeInner) axis.tickSizeInner(tickSizeInner);
     if (tickSizeOuter) axis.tickSizeOuter(tickSizeOuter);
-    if (tickPadding) axis.tickPadding(tickPadding);
     if (tickValues) axis.tickValues(tickValues);
 
     this._axisSelection

--- a/src/ui/axis/src/axis.jsx
+++ b/src/ui/axis/src/axis.jsx
@@ -38,7 +38,12 @@ export const AXIS_TYPES = {
  */
 export default class Axis extends React.PureComponent {
   static concatStyle(style) {
-    return trim(reduce(style, (accum, value, attr) => `${accum} ${attr}: ${value};`, ''));
+    return trim(reduce(
+      style,
+      (accum, value, attr) =>
+        `${accum} ${attr.replace(/([A-Z])/g, '-$1').toLowerCase()}: ${value};`,
+      ''
+    ));
   }
 
   constructor(props) {

--- a/src/ui/axis/src/axis.jsx
+++ b/src/ui/axis/src/axis.jsx
@@ -22,6 +22,7 @@ import {
   CommonPropTypes,
   propsChanged,
   stateFromPropUpdates,
+  camelToKebabCase,
 } from '../../../utils';
 
 import styles from './axis.css';
@@ -40,8 +41,7 @@ export default class Axis extends React.PureComponent {
   static concatStyle(style) {
     return trim(reduce(
       style,
-      (accum, value, attr) =>
-        `${accum} ${attr.replace(/([A-Z])/g, '-$1').toLowerCase()}: ${value};`,
+      (accum, value, attr) => `${accum} ${camelToKebabCase(attr)}: ${value};`,
       ''
     ));
   }

--- a/src/ui/axis/src/axis.jsx
+++ b/src/ui/axis/src/axis.jsx
@@ -117,8 +117,8 @@ export default class Axis extends React.PureComponent {
         ? this._axisSelection
           .selectAll('text')
           .style('text-anchor', 'end')
-          .attr('dx', '-.8em')
-          .attr('dy', '.15em')
+          .attr('dx', '-0.8em')
+          .attr('dy', '0.15em')
           .attr('transform', 'rotate(-45)')
         : this._axisSelection
           .selectAll('text')
@@ -132,8 +132,8 @@ export default class Axis extends React.PureComponent {
         ? this._axisSelection
           .selectAll('text')
           .style('text-anchor', 'end')
-          .attr('dx', '-.8em')
-          .attr('dy', '0.29em')
+          .attr('dx', '-0.65em')
+          .attr('dy', '0.45em')
           .attr('transform', 'rotate(45)')
         : this._axisSelection
           .selectAll('text')

--- a/src/ui/axis/src/orientedAxis.js
+++ b/src/ui/axis/src/orientedAxis.js
@@ -99,6 +99,8 @@ export default function orientAxis(AxisComponent, orientation) {
   OrientedAxis.defaultProps = {
     tickFontFamily: 'Helvetica',
     tickFontSize: 12,
+    tickPadding: 3,
+    tickSize: 6,
   };
 
   OrientedAxis.propUpdates = {

--- a/src/ui/axis/test/axis.test.js
+++ b/src/ui/axis/test/axis.test.js
@@ -20,12 +20,12 @@ describe('<Axis />', () => {
     const tickValues = range(0, 20);
 
     describe('filterTickValuesByWidth', () => {
-      const tickLabelFontSize = 12;
-      const tickLabelFontFamily = 'Verdana';
+      const tickFontSize = 12;
+      const tickFontFamily = 'Verdana';
 
       it('returns all ticks given enough width', () => {
         expect(filterTickValuesByWidth(tickValues,
-          { width: 4000, tickLabelFontSize, tickLabelFontFamily }
+          { width: 4000, tickFontSize, tickFontFamily }
         ))
           .to.be.an('array')
           .of.length(tickValues.length)
@@ -34,7 +34,7 @@ describe('<Axis />', () => {
 
       it('returns a filtered list of ticks given not enough width', () => {
         expect(filterTickValuesByWidth(tickValues,
-          { width: 10, tickLabelFontSize, tickLabelFontFamily }
+          { width: 10, tickFontSize, tickFontFamily }
         ))
           .to.be.an('array')
           .of.length.lessThan(tickValues.length);
@@ -43,14 +43,14 @@ describe('<Axis />', () => {
 
     describe('filterTickValuesByHeight', () => {
       it('returns all ticks given enough height', () => {
-        expect(filterTickValuesByHeight(tickValues, { height: 4000, tickLabelFontSize: 12 }))
+        expect(filterTickValuesByHeight(tickValues, { height: 4000, tickFontSize: 12 }))
           .to.be.an('array')
           .of.length(tickValues.length)
           .and.to.deep.equal(tickValues);
       });
 
       it('returns a filtered list of ticks given not enough height', () => {
-        expect(filterTickValuesByHeight(tickValues, { height: 10, tickLabelFontSize: 12 }))
+        expect(filterTickValuesByHeight(tickValues, { height: 10, tickFontSize: 12 }))
           .to.be.an('array')
           .of.length.lessThan(tickValues.length);
       });

--- a/src/ui/axis/test/utils.test.js
+++ b/src/ui/axis/test/utils.test.js
@@ -16,7 +16,7 @@ describe('<Axis /> utils', () => {
 
     const expectedResults = {
       top: { x: 50, y: 0, dX: 25, dY: '1em', rotate: 0 },
-      bottom: { x: 50, y: 100, dX: 25, dY: '-0.2em', rotate: 0 },
+      bottom: { x: 50, y: 100, dX: 25, dY: '-0.25em', rotate: 0 },
       left: { x: 50, y: 0, dX: -25, dY: '1em', rotate: 270 },
       right: { x: 50, y: -100, dX: 25, dY: '1em', rotate: 90 },
     };

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -95,7 +95,7 @@ export function calcLabelPosition(orientation, translate, padding, center) {
         x: translate.x,
         y: translate.y - padding.top,
         dX: center,
-        dY: '1em', // Shift text baseline down 1em
+        dY: '1em', // Text baseline is positioned at top edge of SVG. Shift down 1em.
         rotate: 0,
       };
     case 'bottom':

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -27,11 +27,11 @@ import {
 } from './strings';
 
 export const DEFAULT_AXIS_PROPERTIES = {
-  axisLabelFontSize: 11,
+  axisLabelFontSize: 16,
   height: 100,
   tickHeight: 10,
   tickLabelFontFamily: 'Helvetica',
-  tickLabelFontSize: 10,
+  tickLabelFontSize: 11,
   tickLabelFormat: null,
   width: 230,
 };
@@ -365,11 +365,12 @@ function calcPaddingFromTicks({
  * @returns {{top: Number, right: Number, bottom: Number, left: Number}} Padding offset from label.
  */
 function getLabelPadding(orientedAxisWithLabel) {
-  return parseFloat((get(
+  const labelFontSize = parseFloat((get(
     orientedAxisWithLabel,
-    ['props', 'style', 'fontSize'],
+    ['props', 'labelStyle', 'fontSize'],
     `${DEFAULT_AXIS_PROPERTIES.axisLabelFontSize}px`
-  )))
+  )));
+  return (labelFontSize * FONT_HEIGHT_SCALING_FACTOR)
   + parseFloat(ADDITIONAL_LABEL_PADDING);
 }
 

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -40,8 +40,7 @@ export const ALLOWED_SCALE_TYPES_FOR_AUTOFORMAT = ['point', 'ordinal', 'band'];
 
 const AXIS_ORIENTATION_OPTIONS = ['top', 'right', 'bottom', 'left'];
 
-const ADDITIONAL_LABEL_PADDING = '7px';
-
+const ADDITIONAL_LABEL_PADDING = '3px';
 
 const TICK_LABEL_ROTATION_ANGLE = -45;
 
@@ -139,16 +138,16 @@ export function calcLabelPosition(orientation, translate, padding, center) {
  * @returns {Number} Number of ticks that fit (without overlap) into available width.
  */
 function calcLengthOfLongestTickLabel(ticks, {
-  tickFontSize: tickLabelFontSize,
-  tickFontFamily: tickLabelFontFamily,
-  tickFormat: tickLabelFormat,
+  tickFontSize,
+  tickFontFamily,
+  tickFormat,
 }) {
   /* eslint-disable max-len */
-  const formattedTicks = map(ticks, tickLabelFormat);
+  const formattedTicks = map(ticks, tickFormat);
   return reduce(formattedTicks, (widest, tick) =>
     Math.max(
       widest,
-      getRenderedStringWidth(String(tick), `${tickLabelFontSize}px ${tickLabelFontFamily}`),
+      getRenderedStringWidth(String(tick), `${tickFontSize}px ${tickFontFamily}`),
     )
   , 0);
 }
@@ -183,8 +182,8 @@ export function filterTickValuesByWidth(ticks, axisProperties) {
  * @param {Number} styles.tickFontSize - Supplied tick font size.
  * @returns {Array} Tick values evenly filtered based on available height.
  */
-export function filterTickValuesByHeight(ticks, { height, tickFontSize: tickLabelFontSize }) {
-  const numTicksThatFit = Math.floor(height / tickLabelFontSize);
+export function filterTickValuesByHeight(ticks, { height, tickFontSize }) {
+  const numTicksThatFit = Math.floor(height / tickFontSize);
   return takeSkipping(ticks, numTicksThatFit);
 }
 
@@ -245,8 +244,8 @@ function calcPaddingFromTickMarks(axes) {
     axes,
     (axis) => {
       if (axis) {
-        const tickSize = get(axis, ['props', 'tickSize'], DEFAULT_D3_TICK_SIZE);
-        const tickPadding = get(axis, ['props', 'tickPadding'], DEFAULT_D3_TICK_PADDING);
+        const tickSize = axis.props.tickSize;
+        const tickPadding = axis.props.tickPadding;
         return tickSize + tickPadding;
       // eslint-disable-next-line no-else-return
       } else {

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -39,7 +39,9 @@ export const ALLOWED_SCALE_TYPES_FOR_AUTOFORMAT = ['point', 'ordinal', 'band'];
 
 const AXIS_ORIENTATION_OPTIONS = ['top', 'right', 'bottom', 'left'];
 
-const ADDITIONAL_LABEL_PADDING = '20px';
+const ADDITIONAL_LABEL_PADDING = '15px';
+
+const ADDITIONAL_ROTATED_TICK_PADDING = '5px';
 
 const TICK_LABEL_ROTATION_ANGLE = -45;
 
@@ -298,13 +300,15 @@ function calcPaddingFromTicks({
     autoRotate = true;
     padding = {
       top: (topAxis && canAutoFormatXAxis)
-        ? sizeOfLongestRotatedString(topAxisTickValues, tickLabelFontSize, TICK_LABEL_ROTATION_ANGLE) - tickLabelFontSize
+        ? sizeOfLongestRotatedString(topAxisTickValues, tickLabelFontSize, TICK_LABEL_ROTATION_ANGLE)
+        + parseFloat(ADDITIONAL_ROTATED_TICK_PADDING)
         : 0,
       right: (rightAxis && canAutoFormatYAxis)
         ? calcLengthOfLongestTickLabel(rightAxisTickValues, axisProperties)
         : 0,
       bottom: (bottomAxis && canAutoFormatXAxis)
-        ? sizeOfLongestRotatedString(bottomAxisTickValues, tickLabelFontSize, TICK_LABEL_ROTATION_ANGLE) - tickLabelFontSize
+        ? sizeOfLongestRotatedString(bottomAxisTickValues, tickLabelFontSize, TICK_LABEL_ROTATION_ANGLE)
+        + parseFloat(ADDITIONAL_ROTATED_TICK_PADDING)
         : 0,
       left: (leftAxis && canAutoFormatYAxis)
         ? calcLengthOfLongestTickLabel(leftAxisTickValues, axisProperties)

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -294,8 +294,8 @@ function calcPaddingFromTicks({
   // RIGHT/LEFT: Ticks cannot overlap. Simply calculate the length of the string (i.e., at 90 deg.)
   let autoRotate;
   let padding;
-  if (numTicksThatFitOnTopAxis < topAxisTickValues.length
-    || numTicksThatFitOnBottomAxis < bottomAxisTickValues.length
+  if (numTicksThatFitOnTopAxis < get(topAxisTickValues, 'length', 0)
+    || numTicksThatFitOnBottomAxis < get(bottomAxisTickValues, 'length', 0)
   ) {
     autoRotate = true;
     padding = {

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -138,9 +138,9 @@ export function calcLabelPosition(orientation, translate, padding, center) {
  * @returns {Number} Number of ticks that fit (without overlap) into available width.
  */
 function calcLengthOfLongestTickLabel(ticks, {
-  tickLabelFontSize,
-  tickLabelFontFamily,
-  tickLabelFormat,
+  tickFontSize: tickLabelFontSize,
+  tickFontFamily: tickLabelFontFamily,
+  tickFormat: tickLabelFormat,
 }) {
   /* eslint-disable max-len */
   const formattedTicks = map(ticks, tickLabelFormat);
@@ -182,7 +182,7 @@ export function filterTickValuesByWidth(ticks, axisProperties) {
  * @param {Number} styles.tickFontSize - Supplied tick font size.
  * @returns {Array} Tick values evenly filtered based on available height.
  */
-export function filterTickValuesByHeight(ticks, { height, tickLabelFontSize }) {
+export function filterTickValuesByHeight(ticks, { height, tickFontSize: tickLabelFontSize }) {
   const numTicksThatFit = Math.floor(height / tickLabelFontSize);
   return takeSkipping(ticks, numTicksThatFit);
 }
@@ -270,8 +270,8 @@ function calcPaddingFromTicks({
 
   // Determine axis style properties.
   const tickLabelFontSize = get(style, 'fontSize', DEFAULT_AXIS_PROPERTIES.tickLabelFontSize);
-  const tickFontFamily = get(style, 'fontFamily', DEFAULT_AXIS_PROPERTIES.tickLabelFontFamily);
-  const axisProperties = { ...DEFAULT_AXIS_PROPERTIES, tickLabelFontSize, tickFontFamily };
+  const tickLabelFontFamily = get(style, 'fontFamily', DEFAULT_AXIS_PROPERTIES.tickLabelFontFamily);
+  const axisProperties = { ...DEFAULT_AXIS_PROPERTIES, tickLabelFontSize, tickLabelFontFamily };
 
   // Determine if x-axis tick labels require rotation (not needed for y-axis since overlap is not a concern)
   // If both top & bottom axes exist and one requires rotation, then rotate both.

--- a/src/utils/axis.js
+++ b/src/utils/axis.js
@@ -42,9 +42,6 @@ const AXIS_ORIENTATION_OPTIONS = ['top', 'right', 'bottom', 'left'];
 
 const ADDITIONAL_LABEL_PADDING = '7px';
 
-const DEFAULT_D3_TICK_SIZE = 6;
-
-const DEFAULT_D3_TICK_PADDING = 3;
 
 const TICK_LABEL_ROTATION_ANGLE = -45;
 

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -2,6 +2,14 @@
 
 import memoize from 'lodash/memoize';
 
+/** Due to difficulties in measuring font height, canvasContext.measureText() does not
+ * return a height value. By comparing various rendered SVG text element heights with
+ * their specified font-size, 1.15 is a reasonable scaling factor to
+ * approximate text height.
+ * https://videlais.com/2014/03/16/the-many-and-varied-problems-with-measuring-font-height-for-html5-canvas/
+*/
+export const FONT_HEIGHT_SCALING_FACTOR = 1.15;
+
 const getCanvasContext = memoize(() => {
   if (!window) {
     return false;
@@ -49,30 +57,15 @@ export const getRenderedStringWidth = (
   return Math.ceil(width);
 };
 
-/**
- * Measure rendered height of string
- * @param {String} str -> the string to measure
- * @param {String} font -> https://developer.mozilla.org/en-US/docs/Web/CSS/font
- * @param {CanvasRenderingContext2D} [canvasContext]
- * @return {number}
- */
-export const getRenderedStringHeight = (
-  str = '',
-  font = '10px Helvetica',
-  canvasContext = getCanvasContext(),
-) => {
-  const { height } = getRenderedStringDimensions(str, font, canvasContext);
-  return Math.ceil(height);
-};
-
 export const sizeOfLongestRotatedString = (
   values,
   height, // tickLabelHeight
   rotationAngle = -45,
 ) => values.reduce((result, label) => {
   const width = Math.floor(getRenderedStringWidth(label));
+  const scaledHeight = height * FONT_HEIGHT_SCALING_FACTOR;
   const size = Math.ceil(
-    (height * Math.abs(Math.cos(rotationAngle))) + (width * Math.abs(Math.sin(rotationAngle)))
+    (scaledHeight * Math.abs(Math.cos(rotationAngle))) + (width * Math.abs(Math.sin(rotationAngle)))
   );
   return size > result ? size : result;
 }, 0);

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -69,3 +69,7 @@ export const sizeOfLongestRotatedString = (
   );
   return size > result ? size : result;
 }, 0);
+
+export function camelToKebabCase(str) {
+  return str.replace(/([A-Z])/g, '-$1').toLowerCase();
+}


### PR DESCRIPTION
This PR resolves many of the bugs and fudge factors included in the **IH-75_auto-axis-formatting** merge. The only pieces that aren't calculated dynamically now are the **dx** & **dy** offsets for the tick labels and axis labels. After digging into the d3-axis code and many use cases, it seems that it is common practice to manipulate these offsets until the desired result is achieved. I experimented with various font sizes and text lengths and they all render the appropriate distance from the ticks. Please let me know if you have any suggestions.