### PR TITLE
Fix bug with Legend itemStyle

### DIFF
--- a/src/ui/legend/src/legend.jsx
+++ b/src/ui/legend/src/legend.jsx
@@ -76,7 +76,7 @@ export default class Legend extends React.PureComponent {
         className={itemClassName}
         key={propResolver(item, labelKey)}
         item={item}
-        style={itemStyle}
+        style={item.itemStyle}
         {...itemProps}
       />
     );


### PR DESCRIPTION
Apply itemStyle appropriately to ItemComponent in legend.jsx.
https://github.com/ihmeuw/ihme-ui/blob/master/src/ui/legend/README.md
According to the docs (see above) itemStyle should be able to be applied to each li within each Legend. This bug fix allows this functionality to work.