### PR TITLE
FGH-681 map accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,25 +65,23 @@ import { AxisChart, linspace } from 'ihme-ui';
 4. Create a new ticket branch and check it out.
 `git checkout -b ticket-branch-name`
 5. Make your code changes. 
-6. From the terminal, navigate to whichever component you are changing.
-`cd src/ui/compositions/map`
-7. Run the demo for that component (e.g., map demo). You'll need to re-run this script every time you save additional changes to rebuild the demo. 
+6. Run the demo for that component (e.g., map demo). You'll need to re-run this script every time you save additional changes to rebuild the demo. 
 `npm run demo map`
-8. Open a browser window and enter the path to the demo. For example, http://localhost:8888//ihme-ui/src/ui/compositions/map/demo/index.html (Change the port number to whichever port you're using for local development in MAMP.)
-9. You'll need to refresh the browser every time you rebuild the demo.
-10. Stage changes and commit as necessary.
+7. Open a browser window and enter the path to the demo. For example, http://localhost:8888//ihme-ui/src/ui/compositions/map/demo/index.html (Change the port number to whichever port you're using for local development in MAMP.)
+8. You'll need to refresh the browser every time you rebuild the demo.
+9. Stage changes and commit as necessary.
 ```
 git status // to see changed files`
 git add filename.js // or git add . to add all modified files
 git commit -m "enter your commit message here" // commit your changes locally
 ```
-11. Push up your working branch in order to create a PR.
+10. Push up your working branch in order to create a PR.
 `git push -u origin working-branch-name`
-12. Go to IHME-UI in Github and click on Compare & Pull Request, then click New Pull Request. 
-13. Select your working branch and which branch you're making the request onto (typically main).
-14. Add a description of the changes.
-15. Add other IHME developers as reviewers
-16. Click Create Pull Request.  
+11. Go to IHME-UI in Github and click on Compare & Pull Request, then click New Pull Request. 
+12. Select your working branch and which branch you're making the request onto (typically main).
+13. Add a description of the changes.
+14. Add other IHME developers as reviewers
+15. Click Create Pull Request.  
 ---
 
 ## API Reference

--- a/README.md
+++ b/README.md
@@ -62,26 +62,31 @@ import { AxisChart, linspace } from 'ihme-ui';
 2. Open a terminal, navigate to where you have your repos saved, then clone.
 `git clone theUrlFromGithubgoes.here`
 3. Be sure to [set up a personal token](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/); you'll need it to push up your working branch to the remote.
-4. Create a new ticket branch and check it out.
+4. Change to the ihme-ui directory and install dependencies. 
+```
+cd ihme-ui
+npm i
+```
+5. Create a new ticket branch and check it out.
 `git checkout -b ticket-branch-name`
-5. Make your code changes. 
-6. Run the demo for that component (e.g., map demo). You'll need to re-run this script every time you save additional changes to rebuild the demo. 
+6. Make your code changes. 
+7. Run the demo for that component (e.g., map demo). You'll need to re-run this script every time you save additional changes to rebuild the demo. 
 `npm run demo map`
-7. Open a browser window and enter the path to the demo. For example, http://localhost:8888//ihme-ui/src/ui/compositions/map/demo/index.html (Change the port number to whichever port you're using for local development in MAMP.)
-8. You'll need to refresh the browser every time you rebuild the demo.
-9. Stage changes and commit as necessary.
+8. Open a browser window and enter the path to the demo. For example, http://localhost:8888//ihme-ui/src/ui/compositions/map/demo/index.html (Change the port number to whichever port you're using for local development in MAMP.)
+9. You'll need to refresh the browser every time you rebuild the demo.
+10. Stage changes and commit as necessary.
 ```
 git status // to see changed files`
 git add filename.js // or git add . to add all modified files
 git commit -m "enter your commit message here" // commit your changes locally
 ```
-10. Push up your working branch in order to create a PR.
+11. Push up your working branch in order to create a PR.
 `git push -u origin working-branch-name`
-11. Go to IHME-UI in Github and click on Compare & Pull Request, then click New Pull Request. 
-12. Select your working branch and which branch you're making the request onto (typically main).
-13. Add a description of the changes.
-14. Add other IHME developers as reviewers
-15. Click Create Pull Request.  
+12. Go to IHME-UI in Github and click on Compare & Pull Request, then click New Pull Request. 
+13. Select your working branch and which branch you're making the request onto (typically main).
+14. Add a description of the changes.
+15. Add other IHME developers as reviewers
+16. Click Create Pull Request.  
 ---
 
 ## API Reference

--- a/README.md
+++ b/README.md
@@ -57,7 +57,33 @@ In support of this, `ihme-ui` exposes both a CommonJS (i.e., `var ihmeUI = requi
 import { AxisChart, linspace } from 'ihme-ui';
 //...
 ```
-
+## Local development and posting pull requests
+1. In Github, click on the Code dropdown/button to clone the repo. You can use either https or ssh. 
+2. Open a terminal, navigate to where you have your repos saved, then clone.
+`git clone theUrlFromGithubgoes.here`
+3. Be sure to [set up a personal token](https://github.blog/2020-12-15-token-authentication-requirements-for-git-operations/); you'll need it to push up your working branch to the remote.
+4. Create a new ticket branch and check it out.
+`git checkout -b ticket-branch-name`
+5. Make your code changes. 
+6. From the terminal, navigate to whichever component you are changing.
+`cd src/ui/compositions/map`
+7. Run the demo for that component (e.g., map demo). You'll need to re-run this script every time you save additional changes to rebuild the demo. 
+`npm run demo map`
+8. Open a browser window and enter the path to the demo. For example, http://localhost:8888//ihme-ui/src/ui/compositions/map/demo/index.html (Change the port number to whichever port you're using for local development in MAMP.)
+9. You'll need to refresh the browser every time you rebuild the demo.
+10. Stage changes and commit as necessary.
+```
+git status // to see changed files`
+git add filename.js // or git add . to add all modified files
+git commit -m "enter your commit message here" // commit your changes locally
+```
+11. Push up your working branch in order to create a PR.
+`git push -u origin working-branch-name`
+12. Go to IHME-UI in Github and click on Compare & Pull Request, then click New Pull Request. 
+13. Select your working branch and which branch you're making the request onto (typically main).
+14. Add a description of the changes.
+15. Add other IHME developers as reviewers
+16. Click Create Pull Request.  
 ---
 
 ## API Reference

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "Katherine Beame <katherine.beame@gmail.com> (https://github.com/kbeame)",
     "Jim Vermillion <jam.mcmillion@gmail.com> (https://github.com/jimvermillion)",
     "Bao Dinh <bdinh@uw.edu> (https://github.com/bdinh)",
-    "Ben Hurst <bhurst8@gmail.com> (https://github.com/benbenbuhben)"
+    "Ben Hurst <bhurst8@gmail.com> (https://github.com/benbenbuhben)",
+    "Melissa Lafranchise <pulchrit@gmail.com (https://github.com/pulchrit)"
   ],
   "repository": "https://github.com/ihmeuw/ihme-ui.git",
   "bugs": "https://github.com/ihmeuw/ihme-ui/issues",

--- a/src/ui/axis/src/axis.jsx
+++ b/src/ui/axis/src/axis.jsx
@@ -72,6 +72,7 @@ export default class Axis extends React.PureComponent {
   drawAxis() {
     const {
       className,
+      legendAriaHideTickMarks,
       orientation,
       rotateTickLabels,
       scale,
@@ -106,6 +107,7 @@ export default class Axis extends React.PureComponent {
     if (tickValues) axis.tickValues(tickValues);
 
     this._axisSelection
+      .attr('aria-hidden', `${legendAriaHideTickMarks}`)
       .attr('class', classNames(styles.common, className))
       .attr('transform', `translate(${translate.x}, ${translate.y})`)
       .attr('style', Axis.concatStyle(style))
@@ -239,6 +241,7 @@ Axis.propTypes = {
    * inline styles applied to text element surrounding axis label
    */
   labelStyle: PropTypes.object,
+  legendAriaHideTickMarks: PropTypes.bool,
 
   /**
    * where to position axis line; will position ticks accordingly
@@ -331,6 +334,7 @@ Axis.propTypes = {
 
 Axis.defaultProps = {
   height: 30,
+  legendAriaHideTickMarks: true,
   padding: {
     top: 40,
     bottom: 40,

--- a/src/ui/button/src/button.jsx
+++ b/src/ui/button/src/button.jsx
@@ -32,6 +32,7 @@ export default class Button extends React.PureComponent {
 
   render() {
     const {
+      ariaLabel,
       children,
       className,
       disabled,
@@ -52,6 +53,7 @@ export default class Button extends React.PureComponent {
 
     return (
       <button
+        aria-label={ariaLabel}
         style={this.combineStyles(styleList)}
         className={classNames(styles.common, styles[theme], className, {
           [disabledClassName]: disabled,
@@ -80,6 +82,7 @@ export default class Button extends React.PureComponent {
 }
 
 Button.propTypes = {
+  ariaLabel: PropTypes.string,
   /**
    * className applied to button
    */
@@ -153,6 +156,7 @@ Button.propTypes = {
 };
 
 Button.defaultProps = {
+  ariaLabel: '',
   disabledClassName: styles.disabled,
 };
 

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -355,7 +355,6 @@ export default class Choropleth extends React.Component {
 
   render() {
     const { width, height } = this.props;
-
     return (
       <div
         className={classNames(style.common, this.props.className)}

--- a/src/ui/choropleth/src/choropleth.jsx
+++ b/src/ui/choropleth/src/choropleth.jsx
@@ -370,6 +370,8 @@ export default class Choropleth extends React.Component {
           onZoomReset={this.zoomReset}
         />}
         <svg
+          aria-label={this.props.ariaLabelMap}
+          role="img"
           ref={this.saveSvgRef}
           width={`${width}px`}
           height={`${height}px`}
@@ -384,6 +386,7 @@ export default class Choropleth extends React.Component {
 }
 
 Choropleth.propTypes = {
+  ariaLabelMap: PropTypes.string,
   /**
    * className applied to outermost div
    */
@@ -620,6 +623,7 @@ Choropleth.propTypes = {
 };
 
 Choropleth.defaultProps = {
+  ariaLabelMap: '',
   controls: false,
   height: 400,
   layers: [],

--- a/src/ui/choropleth/src/controls.css
+++ b/src/ui/choropleth/src/controls.css
@@ -25,6 +25,9 @@
   /* override button's default justify-content: space-between */
   justify-content: center;
 
-  /* make smaller than default 27px */
-  height: 22px;
+  height: 40px;
+  margin: 1px;
+  padding: 4px;
+  width: 40px;
+  
 }

--- a/src/ui/choropleth/src/controls.css
+++ b/src/ui/choropleth/src/controls.css
@@ -10,24 +10,25 @@
 .wrapper button:first-child {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  font-size: 20px;
 }
 
 .wrapper button:nth-child(2) {
   border-radius: 0;
+  font-size: 26px;
 }
 
 .wrapper button:last-child {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+  font-size: 26px;
 }
 
 .wrapper > .button {
   /* override button's default justify-content: space-between */
   justify-content: center;
-
   height: 40px;
   margin: 1px;
   padding: 4px;
   width: 40px;
-  
 }

--- a/src/ui/choropleth/src/controls.jsx
+++ b/src/ui/choropleth/src/controls.jsx
@@ -10,18 +10,21 @@ export default function Controls(props) {
   return (
     <div className={classNames(style.wrapper, props.className)} style={props.style}>
       <Button
+        ariaLabel="Zoom in"
         className={classNames(style.button, props.buttonClassName)}
         onClick={props.onZoomIn}
         style={props.buttonStyle}
         text="+"
       />
       <Button
+        ariaLabel="Default zoom level"
         className={classNames(style.button, props.buttonClassName)}
         onClick={props.onZoomReset}
         style={props.buttonStyle}
         text="•"
       />
       <Button
+        ariaLabel="Zoom out"
         className={classNames(style.button, props.buttonClassName)}
         onClick={props.onZoomOut}
         style={props.buttonStyle}

--- a/src/ui/compositions/choropleth-legend/src/choropleth-legend.jsx
+++ b/src/ui/compositions/choropleth-legend/src/choropleth-legend.jsx
@@ -57,6 +57,7 @@ export default class ChoroplethLegend extends React.PureComponent {
       focus,
       focusedClassName,
       focusedStyle,
+      legendAriaHideTickMarks,
       margins,
       colorAccessor,
       colorSteps,
@@ -86,7 +87,11 @@ export default class ChoroplethLegend extends React.PureComponent {
     const sliderHeight = 10 + (5 * zoom);
 
     return (
-      <svg role="img" width={width} height={height}>
+      <svg
+        aria-label={`Legend showing values from ${sliderHandleFormat(rangeExtent[0])} to ${sliderHandleFormat(rangeExtent[1])}.`}
+        height={height}
+        width={width}
+      >
         <g transform={`translate(${margins.left}, ${margins.top})`}>
           <Scatter
             colorAccessor={colorAccessor}
@@ -132,6 +137,7 @@ export default class ChoroplethLegend extends React.PureComponent {
             <XAxis
               autoFilterTickValues
               label={unit}
+              legendAriaHideTickMarks={legendAriaHideTickMarks}
               orientation="bottom"
               scales={scatterScaleMap}
               translate={axisTranslate}
@@ -219,6 +225,7 @@ ChoroplethLegend.propTypes = {
     PropTypes.string,
     PropTypes.func,
   ]),
+  legendAriaHideTickMarks: PropTypes.bool,
 
   /**
    * margins to subtract from width and height
@@ -331,6 +338,7 @@ ChoroplethLegend.defaultProps = {
     y: 20
   },
   colorSteps: defaultColorSteps,
+  legendAriaHideTickMarks: true,
   margins: {
     top: 50,
     right: 100,

--- a/src/ui/compositions/choropleth-legend/src/choropleth-legend.jsx
+++ b/src/ui/compositions/choropleth-legend/src/choropleth-legend.jsx
@@ -49,6 +49,7 @@ export default class ChoroplethLegend extends React.PureComponent {
 
   render() {
     const {
+      ariaHideScatterGroup,
       axisTickFormat,
       axisTranslate,
       domain,
@@ -94,6 +95,7 @@ export default class ChoroplethLegend extends React.PureComponent {
       >
         <g transform={`translate(${margins.left}, ${margins.top})`}>
           <Scatter
+            ariaHideScatterGroup={ariaHideScatterGroup}
             colorAccessor={colorAccessor}
             colorScale={colorScale}
             data={data}
@@ -152,6 +154,7 @@ export default class ChoroplethLegend extends React.PureComponent {
 }
 
 ChoroplethLegend.propTypes = {
+  ariaHideScatterGroup: PropTypes.bool,
   /**
    * [format of axis ticks](https://github.com/d3/d3-axis#axis_tickFormat)
    */
@@ -332,6 +335,7 @@ ChoroplethLegend.propTypes = {
 };
 
 ChoroplethLegend.defaultProps = {
+  ariaHideScatterGroup: false,
   axisTickFormat: numberFormat,
   axisTranslate: {
     x: 0,

--- a/src/ui/compositions/choropleth-legend/src/choropleth-legend.jsx
+++ b/src/ui/compositions/choropleth-legend/src/choropleth-legend.jsx
@@ -86,7 +86,7 @@ export default class ChoroplethLegend extends React.PureComponent {
     const sliderHeight = 10 + (5 * zoom);
 
     return (
-      <svg width={width} height={height}>
+      <svg role="img" width={width} height={height}>
         <g transform={`translate(${margins.left}, ${margins.top})`}>
           <Scatter
             colorAccessor={colorAccessor}

--- a/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
@@ -62,9 +62,7 @@ export default class SliderHandle extends React.Component {
 
   componentDidMount() {
     this.bindInteract(this._handle);
-
-    const sliderElement = document.querySelector(`#slider-${this.props.whichSliderHandle}`);
-    sliderElement.addEventListener('keydown', this.onSliderKeyDown);
+    this._handle.addEventListener('keydown', this.onSliderKeyDown);
   }
 
   componentWillUnmount() {

--- a/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
@@ -76,6 +76,7 @@ export default class SliderHandle extends React.Component {
 
   onSliderKeyDown(event) {
     event.stopImmediatePropagation();
+    event.preventDefault();
     const { onSliderKeyboardMove, whichSliderHandle } = this.props;
     if (event.code === 'ArrowRight'
       || event.code === 'ArrowDown'

--- a/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
@@ -26,13 +26,13 @@ const propTypes = {
   /* label format function; given props.label as argument; defaults to identity function */
   labelFormat: PropTypes.func,
 
-  /* fn of signature function(mouse::clientX, whichHandle) */
+  /* fn of signature function(mouse::clientX, whichSliderHandle) */
   onSliderMove: PropTypes.func,
 
   /* used for keyboard interaction */
   onSliderKeyboardMove: PropTypes.func,
 
-  which: PropTypes.oneOf(['x1', 'x2'])
+  whichSliderHandle: PropTypes.oneOf(['x1', 'x2'])
 };
 
 const defaultProps = {
@@ -43,7 +43,7 @@ const defaultProps = {
   height: 15,
   label: null,
   labelFormat: (n) => n,
-  which: 'x1'
+  whichSliderHandle: 'x1'
 };
 
 export default class SliderHandle extends React.Component {
@@ -58,7 +58,7 @@ export default class SliderHandle extends React.Component {
   componentDidMount() {
     this.bindInteract(this._handle);
 
-    const sliderElement = document.querySelector(`#slider-${this.props.which}`);
+    const sliderElement = document.querySelector(`#slider-${this.props.whichSliderHandle}`);
     sliderElement.addEventListener('keydown', this.onSliderKeyDown);
   }
 
@@ -67,13 +67,13 @@ export default class SliderHandle extends React.Component {
   }
 
   onHandleMove(evt) {
-    const { onSliderMove, which } = this.props;
-    onSliderMove(evt.dx, which);
+    const { onSliderMove, whichSliderHandle } = this.props;
+    onSliderMove(evt.dx, whichSliderHandle);
   }
 
   onSliderKeyDown(event) {
     event.stopImmediatePropagation();
-    const { onSliderKeyboardMove, which } = this.props;
+    const { onSliderKeyboardMove, whichSliderHandle } = this.props;
     if (event.code === 'ArrowRight'
       || event.code === 'ArrowDown'
       || event.code === 'ArrowLeft'
@@ -81,7 +81,7 @@ export default class SliderHandle extends React.Component {
       || event.code === 'PageUp'
       || event.code === 'PageDown'
     ) {
-      onSliderKeyboardMove(event.code, which);
+      onSliderKeyboardMove(event.code, whichSliderHandle);
     }
   }
 
@@ -102,20 +102,20 @@ export default class SliderHandle extends React.Component {
   }
 
   render() {
-    const { position, which, label, labelFormat, height } = this.props;
+    const { position, whichSliderHandle, label, labelFormat, height } = this.props;
     const handleHeight = height + 5;
 
     return (
       <g
         aria-label={this.props.ariaLabel}
         className={classNames(style.handle)}
-        id={`slider-${which}`}
+        id={`slider-${whichSliderHandle}`}
         ref={this.storeReference}
         tabIndex={0}
         onKeyDown={this.onSliderKeyDown}
       >
         <rect
-          transform={`translate(${which === 'x1' ? -5 : 0}, -2.5)`}
+          transform={`translate(${whichSliderHandle === 'x1' ? -5 : 0}, -2.5)`}
           x={`${position}px`}
           height={`${handleHeight}px`}
           stroke="none"
@@ -125,9 +125,9 @@ export default class SliderHandle extends React.Component {
         </rect>
         <SvgText
           value={labelFormat(label)}
-          anchor={which === 'x1' ? 'end' : 'start'}
+          anchor={whichSliderHandle === 'x1' ? 'end' : 'start'}
           x={position}
-          dx={which === 'x1' ? -8 : 8}
+          dx={whichSliderHandle === 'x1' ? -8 : 8}
           y={14}
         />
       </g>

--- a/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
@@ -7,6 +7,7 @@ import SvgText from '../../../svg-text';
 import style from './slider-handle.css';
 
 const propTypes = {
+  ariaLabel: PropTypes.string,
   /* top margin applied within svg document handle is placed within; used to calc origin offset */
   marginTop: PropTypes.number,
 
@@ -28,10 +29,14 @@ const propTypes = {
   /* fn of signature function(mouse::clientX, whichHandle) */
   onSliderMove: PropTypes.func,
 
+  /* used for keyboard interaction */
+  onSliderKeyboardMove: PropTypes.func,
+
   which: PropTypes.oneOf(['x1', 'x2'])
 };
 
 const defaultProps = {
+  ariaLabel: '',
   marginTop: 0,
   marginLeft: 0,
   position: 0,
@@ -47,10 +52,14 @@ export default class SliderHandle extends React.Component {
 
     this.storeReference = this.storeReference.bind(this);
     this.onHandleMove = this.onHandleMove.bind(this);
+    this.onSliderKeyDown = this.onSliderKeyDown.bind(this);
   }
 
   componentDidMount() {
     this.bindInteract(this._handle);
+
+    const sliderElement = document.querySelector(`#slider-${this.props.which}`);
+    sliderElement.addEventListener('keydown', this.onSliderKeyDown);
   }
 
   componentWillUnmount() {
@@ -60,6 +69,20 @@ export default class SliderHandle extends React.Component {
   onHandleMove(evt) {
     const { onSliderMove, which } = this.props;
     onSliderMove(evt.dx, which);
+  }
+
+  onSliderKeyDown(event) {
+    event.stopImmediatePropagation();
+    const { onSliderKeyboardMove, which } = this.props;
+    if (event.code === 'ArrowRight'
+      || event.code === 'ArrowDown'
+      || event.code === 'ArrowLeft'
+      || event.code === 'ArrowUp'
+      || event.code === 'PageUp'
+      || event.code === 'PageDown'
+    ) {
+      onSliderKeyboardMove(event.code, which);
+    }
   }
 
   storeReference(el) {
@@ -84,8 +107,12 @@ export default class SliderHandle extends React.Component {
 
     return (
       <g
+        aria-label={this.props.ariaLabel}
         className={classNames(style.handle)}
+        id={`slider-${which}`}
         ref={this.storeReference}
+        tabIndex={0}
+        onKeyDown={this.onSliderKeyDown}
       >
         <rect
           transform={`translate(${which === 'x1' ? -5 : 0}, -2.5)`}

--- a/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider-handle.jsx
@@ -14,6 +14,9 @@ const propTypes = {
   /* left margin applied within svg document handle is placed within; used to calc origin offset */
   marginLeft: PropTypes.number,
 
+  minValue: PropTypes.number,
+  maxValue: PropTypes.number,
+
   /* the height of element (path, line, rect) that the slider will sit atop, in px */
   height: PropTypes.number,
 
@@ -39,6 +42,8 @@ const defaultProps = {
   ariaLabel: '',
   marginTop: 0,
   marginLeft: 0,
+  minValue: 0,
+  maxValue: 1,
   position: 0,
   height: 15,
   label: null,
@@ -102,14 +107,18 @@ export default class SliderHandle extends React.Component {
   }
 
   render() {
-    const { position, whichSliderHandle, label, labelFormat, height } = this.props;
+    const { position, whichSliderHandle, label, maxValue, minValue, labelFormat, height } = this.props;
     const handleHeight = height + 5;
-
     return (
       <g
         aria-label={this.props.ariaLabel}
+        aria-valuemin={minValue}
+        aria-valuenow={label}
+        aria-valuetext={labelFormat(label)}
+        aria-valuemax={maxValue}
         className={classNames(style.handle)}
         id={`slider-${whichSliderHandle}`}
+        role="slider"
         ref={this.storeReference}
         tabIndex={0}
         onKeyDown={this.onSliderKeyDown}

--- a/src/ui/compositions/choropleth-legend/src/slider.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider.jsx
@@ -29,9 +29,9 @@ export default class Slider extends React.Component {
     this.keyboardSliderMove = this.keyboardSliderMove.bind(this);
   }
 
-  rectWidth(which, edgePosition, containerWidth) {
+  rectWidth(whichSliderHandle, edgePosition, containerWidth) {
     /* eslint no-self-compare:0 */
-    if (which === 'left') return edgePosition || 0;
+    if (whichSliderHandle === 'left') return edgePosition || 0;
 
     // make certain both containerWidth and edgePosition are numbers
     // and not NaN (self-compare check)
@@ -44,7 +44,7 @@ export default class Slider extends React.Component {
     return 0;
   }
 
-  keyboardSliderMove(keyPressed, which) {
+  keyboardSliderMove(keyPressed, whichSliderHandle) {
     const {
       domain,
       onSliderMove,
@@ -59,7 +59,7 @@ export default class Slider extends React.Component {
     const percentChange = changeAmount / width;
     
     // Left slider was changed. Adjust lower domain.
-    if (which === 'x1') {
+    if (whichSliderHandle === 'x1') {
       // Right/Up Arrow and Page Up keys increment.
       if (keyPressed === 'ArrowRight' || keyPressed === 'ArrowUp' || keyPressed === 'PageUp') {
         let newLower = lowerExtent + percentChange;
@@ -71,18 +71,18 @@ export default class Slider extends React.Component {
       if (keyPressed === 'ArrowLeft' || keyPressed === 'ArrowDown' || keyPressed === 'PageDown') {
         let newLower = lowerExtent - percentChange;
         // prevent the slider handles from crossing
-        if (newLower > upperExtent) newLower = upperExtent; // correct?????????
+        if (newLower > upperExtent) newLower = upperExtent;
         lowerExtent = newLower;
       }
     }
 
     // Right slider was changed. Adjust upper domain.
-    if (which === 'x2') {
+    if (whichSliderHandle === 'x2') {
       // Right/Up Arrow and Page Up keys increment.
       if (keyPressed === 'ArrowRight' || keyPressed === 'ArrowUp' || keyPressed === 'PageUp') {
         let newUpper = upperExtent + percentChange;
         // prevent the slider handles from crossing
-        if (newUpper < lowerExtent) newUpper = lowerExtent; // correct??????????
+        if (newUpper < lowerExtent) newUpper = lowerExtent;
         upperExtent = newUpper;
       }
       // Left/Down Arrow and Page Down keys decrement.
@@ -107,9 +107,9 @@ export default class Slider extends React.Component {
   /**
    * Passed as moveHandler to individual brush handles
    * @param {Number} positionChange -> num pixels the handle has been dragged
-   * @param {String} which -> 'x1' or 'x2'
+   * @param {String} whichSliderHandle -> 'x1' or 'x2'
    */
-  decoratedSliderMove(positionChange, which) {
+  decoratedSliderMove(positionChange, whichSliderHandle) {
     const {
       domain,
       onSliderMove,
@@ -123,7 +123,7 @@ export default class Slider extends React.Component {
     const percentChange = positionChange / width;
     const tolerance = 0.005;
 
-    switch (which) {
+    switch (whichSliderHandle) {
       case 'x1':
         positionAsPercent = maybeSnapToBounds(
           tolerance,
@@ -188,7 +188,7 @@ export default class Slider extends React.Component {
         </rect>
         <SliderHandle
           ariaLabel="Change the minimum value displayed on the map."
-          which={'x1'}
+          whichSliderHandle={'x1'}
           position={leftEdgeinPx}
           label={minExtent}
           labelFormat={labelFormat}
@@ -208,7 +208,7 @@ export default class Slider extends React.Component {
         </rect>
         <SliderHandle
           ariaLabel="Change the maximum value displayed on the map."
-          which="x2"
+          whichSliderHandle="x2"
           position={rightEdgeInPx}
           label={maxExtent}
           labelFormat={labelFormat}

--- a/src/ui/compositions/choropleth-legend/src/slider.jsx
+++ b/src/ui/compositions/choropleth-legend/src/slider.jsx
@@ -162,6 +162,7 @@ export default class Slider extends React.Component {
 
   render() {
     const {
+      domain,
       xScale,
       rangeExtent,
       width,
@@ -173,11 +174,12 @@ export default class Slider extends React.Component {
       zoom
     } = this.props;
     const [minExtent, maxExtent] = rangeExtent;
+    const [minDomain, maxDomain] = domain;
     const leftEdgeinPx = xScale(minExtent);
     const rightEdgeInPx = xScale(maxExtent);
 
     return (
-      <g role="slider" transform={`translate(0, ${translateY * zoom})`}>
+      <g transform={`translate(0, ${translateY * zoom})`}>
         <rect
           x="0px"
           height={`${height}px`}
@@ -196,6 +198,7 @@ export default class Slider extends React.Component {
           onSliderKeyboardMove={this.keyboardSliderMove}
           marginTop={marginTop}
           marginLeft={marginLeft}
+          minValue={minDomain}
           height={height}
         />
         <rect
@@ -216,6 +219,7 @@ export default class Slider extends React.Component {
           onSliderKeyboardMove={this.keyboardSliderMove}
           marginTop={marginTop}
           marginLeft={marginLeft}
+          maxValue={maxDomain}
           height={height}
         />
       </g>

--- a/src/ui/compositions/map/README.md
+++ b/src/ui/compositions/map/README.md
@@ -14,6 +14,7 @@ your topojson must conform to the following requirements:
 
 Property | Required | Type(s) | Defaults | Description
 :---    |:---      |:---     |:---      |:---
+`ariaLabelMap` | true | string | '' | the string describing the map for screen readers
 `axisTickFormat` |  | func |  | [format of axis ticks](https://github.com/d3/d3-axis#axis_tickFormat)<br />implicitly defaults to [numberFormat](https://github.com/ihmeuw/ihme-ui/blob/docs/src/utils/numbers.js#L9)
 `className` |  | [CommonPropTypes.className](https://github.com/ihmeuw/ihme-ui/blob/main/src/utils/props.js#L11) |  | className applied to outermost wrapping div
 `colorAccessor` |  | string, func |  | if string, the color property of the datum object; if function, takes in datum object and returns a color string.
@@ -29,6 +30,7 @@ Property | Required | Type(s) | Defaults | Description
 `legendClassName` |  | [CommonPropTypes.className](https://github.com/ihmeuw/ihme-ui/blob/main/src/utils/props.js#L11) |  | classname applied to div containing choropleth legend
 `legendMargins` |  | object | {<br />  top: 20,<br />  right: 50,<br />  bottom: 0,<br />  left: 50,<br />} | margins passed to `<ChoroplethLegend />`<br />subtracted from width and height of `<ChoroplethLegend />`
 `legendStyle` |  | object |  | inline style object applied to div containing choropleth legend
+`legendAriaHideTickMarks` | | boolean | true | Whether or not tick marks in the legend should be hidden from screen readers.
 `loading` |  | bool | false | is data for this component currently being fetched<br />will prevent component from updating (a la shouldComponentUpdate) if true
 `mapClassName` |  | [CommonPropTypes.className](https://github.com/ihmeuw/ihme-ui/blob/main/src/utils/props.js#L11) |  | className applied to div directly wrapping `<Choropleth />`
 `mapStyle` |  | [CommonPropTypes.style](https://github.com/ihmeuw/ihme-ui/blob/main/src/utils/props.js#L16) |  | inline styles applied to div directly wrapping `<Choropleth />`

--- a/src/ui/compositions/map/README.md
+++ b/src/ui/compositions/map/README.md
@@ -14,6 +14,7 @@ your topojson must conform to the following requirements:
 
 Property | Required | Type(s) | Defaults | Description
 :---    |:---      |:---     |:---      |:---
+`ariaHideScatterGroup` | false | boolean | whether or not the scatter group should be hidden from screen readers. 
 `ariaLabelMap` | true | string | '' | the string describing the map for screen readers
 `axisTickFormat` |  | func |  | [format of axis ticks](https://github.com/d3/d3-axis#axis_tickFormat)<br />implicitly defaults to [numberFormat](https://github.com/ihmeuw/ihme-ui/blob/docs/src/utils/numbers.js#L9)
 `className` |  | [CommonPropTypes.className](https://github.com/ihmeuw/ihme-ui/blob/main/src/utils/props.js#L11) |  | className applied to outermost wrapping div

--- a/src/ui/compositions/map/demo/app.jsx
+++ b/src/ui/compositions/map/demo/app.jsx
@@ -222,6 +222,7 @@ class App extends React.Component {
           topology={this.prepTopology(topology)}
           unit="Probability of death"
           valueField={valueField}
+          zoomControlsClassName={'zoom-controls-class'}
         />
         <Button
           onClick={this.onToggleColorAccessor}

--- a/src/ui/compositions/map/demo/app.jsx
+++ b/src/ui/compositions/map/demo/app.jsx
@@ -202,6 +202,7 @@ class App extends React.Component {
     return (
       <div id="wrapper">
         <Map
+          ariaHideScatterGroup={true}
           ariaLabelMap="Demo map aria label"
           axisTickFormat={numberFormat}
           data={data}

--- a/src/ui/compositions/map/demo/app.jsx
+++ b/src/ui/compositions/map/demo/app.jsx
@@ -202,6 +202,7 @@ class App extends React.Component {
     return (
       <div id="wrapper">
         <Map
+          ariaLabelMap="Demo map aria label"
           axisTickFormat={numberFormat}
           data={data}
           domain={range}

--- a/src/ui/compositions/map/src/map.jsx
+++ b/src/ui/compositions/map/src/map.jsx
@@ -267,6 +267,7 @@ export default class Map extends React.Component {
 
   renderMap() {
     const {
+      ariaLabelMap,
       colorAccessor,
       data,
       focus,
@@ -274,6 +275,7 @@ export default class Map extends React.Component {
       focusedStyle,
       keyField,
       geometryKeyField,
+      legendAriaHideTickMarks,
       mapClassName,
       mapStyle,
       onClick,
@@ -294,6 +296,7 @@ export default class Map extends React.Component {
       <div className={classNames(styles.map, mapClassName)} style={mapStyle}>
         <ResponsiveContainer>
           <Choropleth
+            ariaLabelMap={ariaLabelMap}
             controlsButtonClassName={zoomControlsButtonClassName}
             colorAccessor={colorAccessor}
             colorScale={colorScale}
@@ -307,6 +310,7 @@ export default class Map extends React.Component {
             geometryKeyField={geometryKeyField}
             keyField={keyField}
             layers={layers}
+            legendAriaHideTickMarks={legendAriaHideTickMarks}
             onClick={onClick}
             onMouseLeave={onMouseLeave}
             onMouseMove={onMouseMove}
@@ -335,6 +339,7 @@ export default class Map extends React.Component {
       legendClassName,
       legendMargins,
       legendStyle,
+      legendAriaHideTickMarks,
       onClick,
       onMouseLeave,
       onMouseMove,
@@ -370,6 +375,7 @@ export default class Map extends React.Component {
               focusedClassName={focusedClassName}
               focusedStyle={focusedStyle}
               keyField={keyField}
+              legendAriaHideTickMarks={legendAriaHideTickMarks}
               margins={legendMargins}
               onClick={onClick}
               onMouseLeave={onMouseLeave}
@@ -417,6 +423,7 @@ export default class Map extends React.Component {
 }
 
 Map.propTypes = {
+  ariaLabelMap: PropTypes.string,
   /**
    * [format of axis ticks](https://github.com/d3/d3-axis#axis_tickFormat)
    * implicitly defaults to [numberFormat](https://github.com/ihmeuw/ihme-ui/blob/docs/src/utils/numbers.js#L9)
@@ -528,6 +535,7 @@ Map.propTypes = {
    * inline style object applied to div containing choropleth legend
    */
   legendStyle: PropTypes.object,
+  legendAriaHideTickMarks: PropTypes.bool,
 
   /**
    * is data for this component currently being fetched
@@ -677,6 +685,7 @@ Map.propTypes = {
 };
 
 Map.defaultProps = {
+  ariaLabelMap: '',
   colorSteps: defaultColorSteps.slice().reverse(),
   extentPct: [0, 1],
   legendMargins: {
@@ -685,6 +694,7 @@ Map.defaultProps = {
     bottom: 0,
     left: 50,
   },
+  legendAriaHideTickMarks: true,
   loading: false,
   selectedLocations: [],
   topojsonObjects: ['national'],

--- a/src/ui/compositions/map/src/map.jsx
+++ b/src/ui/compositions/map/src/map.jsx
@@ -283,6 +283,7 @@ export default class Map extends React.Component {
       selectedLocations,
       topology,
       valueField,
+      zoomControlsButtonClassName,
       zoomControlsClassName,
       zoomControlsStyle,
     } = this.props;
@@ -293,6 +294,7 @@ export default class Map extends React.Component {
       <div className={classNames(styles.map, mapClassName)} style={mapStyle}>
         <ResponsiveContainer>
           <Choropleth
+            controlsButtonClassName={zoomControlsButtonClassName}
             colorAccessor={colorAccessor}
             colorScale={colorScale}
             controls
@@ -651,6 +653,14 @@ Map.propTypes = {
     PropTypes.string,
     PropTypes.func,
   ]).isRequired,
+
+  /**
+   * className applied to zoom controls buttons
+   */
+  zoomControlsButtonClassName: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.string,
+  ]),
 
   /**
    * className applied to controls container div

--- a/src/ui/compositions/map/src/map.jsx
+++ b/src/ui/compositions/map/src/map.jsx
@@ -326,6 +326,7 @@ export default class Map extends React.Component {
 
   renderLegend() {
     const {
+      ariaHideScatterGroup,
       axisTickFormat,
       colorAccessor,
       colorSteps,
@@ -365,6 +366,7 @@ export default class Map extends React.Component {
         <div className={styles['legend-wrapper']}>
           <ResponsiveContainer>
             <ChoroplethLegend
+              ariaHideScatterGroup={ariaHideScatterGroup}
               axisTickFormat={axisTickFormat}
               colorAccessor={colorAccessor}
               colorSteps={colorSteps}
@@ -423,6 +425,7 @@ export default class Map extends React.Component {
 }
 
 Map.propTypes = {
+  ariaHideScatterGroup: PropTypes.bool,
   ariaLabelMap: PropTypes.string,
   /**
    * [format of axis ticks](https://github.com/d3/d3-axis#axis_tickFormat)
@@ -685,6 +688,7 @@ Map.propTypes = {
 };
 
 Map.defaultProps = {
+  ariaHideScatterGroup: false,
   ariaLabelMap: '',
   colorSteps: defaultColorSteps.slice().reverse(),
   extentPct: [0, 1],

--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -157,6 +157,7 @@ export default class Scatter extends React.PureComponent {
   renderScatter(data) {
     return (
       <g
+        aria-hidden={this.props.ariaHideScatterGroup}
         className={this.props.className && classNames(this.props.className)}
         clipPath={this.props.clipPathId && `url(#${this.props.clipPathId})`}
         style={this.combineStyles(this.props.style, this.props.data)}
@@ -208,6 +209,7 @@ Scatter.animatable = [
 ];
 
 Scatter.propTypes = {
+  ariaHideScatterGroup: PropTypes.bool,
   /**
    * Whether to animate the scatter component (using default `start`, `update` functions).
    * Optionally, an object that provides functions that dictate behavior of animations.
@@ -374,6 +376,7 @@ Scatter.propTypes = {
 };
 
 Scatter.defaultProps = {
+  ariaHideScatterGroup: false,
   animate: false,
   enter: undefined,
   fill: 'steelblue',


### PR DESCRIPTION
This PR makes some accessibility and other improvements to the map zoom and legend controls.

-  I added a classname for the zoom controls button to the Map composition so that it could be passed to Choropleth and the Zoom Controls components. It looks like it was just skipped in the past.
- I changed the styles on the zoom controls to allow for the focus ring to be seen entirely and increased the size of the buttons so that a target area of 48px square (https://hub.ihme.washington.edu/display/DVT/Styling+checklist) was available. I also increased the the font size of the +, - and *. (Focus ring won't be visible in ihme-ui as it has no focus-visible styling enabled.)
- Following the basics of the design pattern for slider (https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#slider), I added keyboard listeners and handlers to allow for keyboard interaction of the choropleth legend slider handles. We use Interact.js for the mouse listeners and handlers, but that package has no keyboard support (https://github.com/taye/interact.js/issues/275). In order to not make a breaking change, I've not switched to a new package. I've just added keyboard handlers in addition to the mouse handlers. 
- I followed the logic for the mouse handler to create  the keyboard handler. 
- I also made a small change to a prop name for clarity; 'which' has been changed to 'whichSliderHandler'.

To test: 
- npm run demo map
- visit: http://localhost:8888//ihme-ui/src/ui/compositions/map/demo/index.html (change port as necessary depending on what MAMP is running on)

Please let me know of changes. Thanks!