### PR TITLE
Fix warning on Scatter component

### DIFF
--- a/src/ui/shape/src/scatter.jsx
+++ b/src/ui/shape/src/scatter.jsx
@@ -51,7 +51,7 @@ export default class Scatter extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.state = stateFromPropUpdates(Scatter.propUpdates, this.props, nextProps, this.state);
+    this.setState(stateFromPropUpdates(Scatter.propUpdates, this.props, nextProps, this.state));
   }
 
   static computeFill(props, datum) {


### PR DESCRIPTION
Assigning directly to this.state is deprecated (except inside a components constructor) updated deprecated use in scatter.jsx to setState instead.

When using the Map component (which includes the legend, and thus the scatter component) there is a warning that has come up for a while involving the deprecated use of assigning this.state. This updates the last use of that in IHME-UI outside of a component constructor.

As seen in other deployments that use ihme-ui
`Warning: t.componentWillReceiveProps(): Assigning directly to this.state is deprecated (except inside a component's constructor). Use setState instead.`

As seen in the demo of map of ihme-ui itself
`react_devtools_backend.js:4026 Warning: Scatter.componentWillReceiveProps(): Assigning directly to this.state is deprecated (except inside a component's constructor). Use setState instead.
    in Scatter (created by ChoroplethLegend)
    in g (created by ChoroplethLegend)
    in svg (created by ChoroplethLegend)
    in ChoroplethLegend (created by Map)
    in div (created by AutoSizer)
    in AutoSizer (created by ResponsiveContainer)
    in ResponsiveContainer (created by Map)
    in div (created by Map)
    in div (created by Map)
    in div (created by Map)
    in Map (created by App)
    in div (created by App)`